### PR TITLE
Add a workflow that runs Tock's license checker.

### DIFF
--- a/.github/workflows/license_check.yaml
+++ b/.github/workflows/license_check.yaml
@@ -1,0 +1,26 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2026.
+
+name: license_check
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone tock-registers
+        uses: actions/checkout@v6
+        with:
+          path: tock-registers
+
+      - name: Clone tock/tock
+        uses: actions/checkout@v6
+        with:
+          path: tock
+          repository: tock/tock
+
+      - name: License check
+        run: cargo run --manifest-path=../tock/tools/ci/license-checker/Cargo.toml --release
+        working-directory: tock-registers

--- a/.lcignore
+++ b/.lcignore
@@ -1,0 +1,9 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2026.
+
+/.git/
+/CHANGELOG.md
+/LICENSE-APACHE
+/LICENSE-MIT
+/README.md


### PR DESCRIPTION
This clones the Tock repository so it can build and run Tock's license checker.

An alternative design would be to split the license checker out into its own repository, so that this doesn't need to clone all of tock/tock. However, that would complicate tock/tock, as it would need to clone the license checker as well (and `make prepush` would need to find the user's copy of the license checker). Since the contribution volume to tock/tock is much higher than tock-registers, this seems like the better tradeoff to me.