### PR TITLE
Add `make test` and a CI workflow that runs it.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,16 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2026.
+
+name: ci
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v6
+      - name: Test
+        run: make -j4 test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2026.
+
+/Cargo.lock
+/target/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2026.
+
+.PHONY: test
+test:
+	+RUSTFLAGS="-D warnings" cargo build --all-targets
+	+RUSTFLAGS="-D warnings" cargo test
+	+RUSTFLAGS="-D warnings" cargo clippy
+	+cargo fmt --check
+	+cd nightly && \
+		RUSTFLAGS="-D warnings" cargo miri test --manifest-path=../Cargo.toml

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 
 .PHONY: test
 test:
+	+RUSTFLAGS="-D warnings" cargo build --all-targets --no-default-features
 	+RUSTFLAGS="-D warnings" cargo build --all-targets
 	+RUSTFLAGS="-D warnings" cargo test
 	+RUSTFLAGS="-D warnings" cargo clippy

--- a/nightly/rust-toolchain.toml
+++ b/nightly/rust-toolchain.toml
@@ -1,0 +1,8 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2026.
+
+# This is the nightly Rust toolchain used by `make test`.
+[toolchain]
+channel = "nightly-2026-01-27"
+components = ["miri", "rust-src"]


### PR DESCRIPTION
`make test` runs a handful of common Rust test commands (cargo check, cargo test, clippy, formatting, plus running tests in miri).

I also added a .gitignore, as otherwise running `cargo check` results in an unclear workspace.