### PR TITLE
Add an MSRV policy; test against the MSRV.

### DIFF
--- a/.github/workflows/license_check.yaml
+++ b/.github/workflows/license_check.yaml
@@ -22,5 +22,5 @@ jobs:
           repository: tock/tock
 
       - name: License check
-        run: cargo run --manifest-path=../tock/tools/ci/license-checker/Cargo.toml --release
+        run: cargo +stable run --manifest-path=../tock/tools/ci/license-checker/Cargo.toml --release
         working-directory: tock-registers

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ keywords = ["tock", "embedded", "registers", "mmio", "bare-metal"]
 categories = ["data-structures", "embedded", "no-std"]
 license = "MIT/Apache-2.0"
 edition = "2021"
+# This must be kept in sync with rust-toolchain.toml; please see that file for
+# more information.
+rust-version = "1.82"
 
 [features]
 default = [ "register_types" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,13 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2026.
+
+[toolchain]
+# This is tock-registers' Minimum Supported Rust Version (MSRV).
+#
+# Update policy: Update this if doing so allows you to use a Rust feature that
+# you'd like to use. When you do so, update this to the first Rust version that
+# includes that feature. Whenever this value is updated, the rust-version field
+# in Cargo.toml must be updated as well.
+channel = "1.82"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
This adds an MSRV policy to tock-registers. This policy currently matches libtock-rs: bump to a newer stable release anytime doing so is convenient. This MSRV is specified in Cargo.toml and, when combined with #6, tests it in CI.

1.82 is the earlier stable Rust version that can run `cargo clippy` without warnings (earlier version give the error clippy::unused_result_ok). Note that 1.82 does *not* support the 2024 edition, if we want to update that then we should switch to 1.85.