### PR TITLE
Make tock-registers a Cargo workspace, add a proc-macro crate.

### DIFF
--- a/.lcignore
+++ b/.lcignore
@@ -6,4 +6,6 @@
 /CHANGELOG.md
 /LICENSE-APACHE
 /LICENSE-MIT
-/README.md
+
+# Files that do not support comments.
+*.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,21 +2,38 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2022.
 
-[package]
-name = "tock-registers"
+[workspace]
+members = []
+
+[workspace.package]
 version = "0.10.1"
 authors = ["Tock Project Developers <devel@lists.tockos.org>"]
-description = "Memory-Mapped I/O and register interface developed for Tock."
 homepage = "https://www.tockos.org/"
 repository = "https://github.com/tock/tock-registers"
 readme = "README.md"
-keywords = ["tock", "embedded", "registers", "mmio", "bare-metal"]
-categories = ["data-structures", "embedded", "no-std"]
 license = "MIT/Apache-2.0"
 edition = "2021"
 # This must be kept in sync with rust-toolchain.toml; please see that file for
 # more information.
 rust-version = "1.82"
+
+[package]
+name = "tock-registers"
+version.workspace = true
+authors.workspace = true
+categories = ["data-structures", "embedded", "no-std"]
+description = "Memory-Mapped I/O and register interface developed for Tock."
+edition.workspace = true
+homepage.workspace = true
+keywords = ["tock", "embedded", "registers", "mmio", "bare-metal"]
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+
+[dependencies.tock-registers-macros]
+optional = true
+path = "macros"
+version = "=0.10.1"
 
 [features]
 default = [ "register_types" ]
@@ -24,7 +41,7 @@ default = [ "register_types" ]
 # Include actual register types (except LocalRegisterCopy). Disabling
 # the feature makes this an interface-only library and removes all
 # usage of unsafe code
-register_types = []
+register_types = ["dep:tock-registers-macros"]
 
 [lints.clippy]
 # CLIPPY CONFIGURATION

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 .PHONY: test
 test:
-	+RUSTFLAGS="-D warnings" cargo build --no-default-features --workspace
+	+RUSTFLAGS="-D warnings" cargo build --no-default-features
 	+RUSTFLAGS="-D warnings" cargo build --all-targets --workspace
 	+RUSTFLAGS="-D warnings" cargo test --all-targets --workspace
 	+RUSTFLAGS="-D warnings" cargo clippy --workspace

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,21 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2026.
 
+# The Miri test takes longer than all the other tests combined, and is mostly
+# sequential (cargo runs individual test binaries sequentially). Therefore, to
+# speed up `make test`, we split the Miri test and other tests into separate
+# targets (miri_test and fast_tests) so they run in parallel.
 .PHONY: test
-test:
+test: miri_test fast_test
+
+.PHONY: fast_test
+fast_test:
 	+RUSTFLAGS="-D warnings" cargo build --no-default-features
 	+RUSTFLAGS="-D warnings" cargo build --all-targets --workspace
 	+RUSTFLAGS="-D warnings" cargo test --all-targets --workspace
 	+RUSTFLAGS="-D warnings" cargo clippy --all --all-targets --workspace
 	+RUSTDOCFLAGS="-D warnings" cargo doc --workspace
 	+cargo fmt --all --check
-	$(MAKE) miri_test
 
 .PHONY: miri_test
 miri_test:

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,15 @@
 
 .PHONY: test
 test:
-	+RUSTFLAGS="-D warnings" cargo build --all-targets --no-default-features
-	+RUSTFLAGS="-D warnings" cargo build --all-targets
-	+RUSTFLAGS="-D warnings" cargo test
-	+RUSTFLAGS="-D warnings" cargo clippy
-	+RUSTDOCFLAGS="-D warnings" cargo doc
-	+cargo fmt --check
-	+cd nightly && \
-		RUSTFLAGS="-D warnings" cargo miri test --manifest-path=../Cargo.toml
+	+RUSTFLAGS="-D warnings" cargo build --no-default-features --workspace
+	+RUSTFLAGS="-D warnings" cargo build --all-targets --workspace
+	+RUSTFLAGS="-D warnings" cargo test --all-targets --workspace
+	+RUSTFLAGS="-D warnings" cargo clippy --workspace
+	+RUSTDOCFLAGS="-D warnings" cargo doc --workspace
+	+cargo fmt --all --check
+	$(MAKE) miri_test
+
+.PHONY: miri_test
+miri_test:
+	+cd nightly && RUSTFLAGS="-D warnings" \
+		cargo miri test --all-targets --manifest-path=../Cargo.toml --workspace

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,0 +1,18 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2026.
+# Copyright Better Bytes 2026.
+
+[package]
+name = "tock-registers-macros"
+version.workspace = true
+authors.workspace = true
+description = "Proc macros for tock-registers"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+
+[lib]
+proc-macro = true

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,0 +1,5 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+// Copyright Better Bytes 2026.
+//


### PR DESCRIPTION
Although we have not decided on a design for the new sound tock-registers interface, I am confident that it will include at least one procedural macro. Procedural macros have to go in their own crate. This adds a new `tock-registers-macros` proc-macro crate, and changes the root Cargo.toml to be a workspace. I also updated the Makefile accordingly, and moved the `miri` invocation out to a separate action (so it is easier to invoke on its own).

I also updated `.lcignore` to ignore all Markdown files, as I am also confident that we will want more documentation files in the future.