### PR TITLE
Add the `Register` and `DataType` traits.

### DIFF
--- a/src/data_type.rs
+++ b/src/data_type.rs
@@ -1,0 +1,39 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+// Copyright Better Bytes 2026.
+
+use crate::{RegisterLongName, UIntLike};
+
+/// Trait implemented by accessors for individual registers.
+pub trait Register: Copy {
+    // TODO: Link `register_map! using [`register_map!`](crate::register_map).
+    /// This register's data type, as specified in `register_map!`'s input.
+    type DataType: DataType;
+}
+
+/// Conveys information about a register's data type.
+pub trait DataType {
+    /// The register's value type. This is the type passed over the bus when accessing the
+    /// register. This will typically be UIntLike, but can sometimes be other types such as raw
+    /// pointers.
+    type Value: Copy;
+
+    /// This register's bitfield.
+    type LongName: RegisterLongName;
+}
+
+impl<U: UIntLike> DataType for U {
+    type Value = U;
+    type LongName = ();
+}
+
+impl<T: Sized> DataType for *const T {
+    type Value = *const T;
+    type LongName = ();
+}
+
+impl<T: Sized> DataType for *mut T {
+    type Value = *mut T;
+    type LongName = ();
+}

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -599,6 +599,10 @@ macro_rules! register_bitfields {
                 #[derive(Clone, Copy)]
                 pub struct Register;
                 impl $crate::RegisterLongName for Register {}
+                impl $crate::DataType for Register {
+                    type Value = $valtype;
+                    type LongName = Self;
+                }
 
                 use $crate::fields::Field;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,23 +61,27 @@
 // If we don't build any actual register types, we don't need unsafe code in
 // this crate
 #![cfg_attr(not(feature = "register_types"), forbid(unsafe_code))]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
+mod data_type;
+pub use data_type::{DataType, Register};
+
+pub mod debug;
 pub mod fields;
 pub mod interfaces;
+
+mod local_register;
+pub use local_register::LocalRegisterCopy;
+
 pub mod macros;
 
 #[cfg(feature = "register_types")]
 pub mod registers;
 
-pub mod debug;
-
-mod local_register;
-pub use local_register::LocalRegisterCopy;
-
 use core::fmt::Debug;
 use core::ops::{BitAnd, BitOr, BitOrAssign, Not, Shl, Shr};
 
-/// Trait representing the base type of registers.
+/// Trait representing the base type of registers that support bitfields.
 ///
 /// UIntLike defines basic properties of types required to read/write/modify a
 /// register through its methods and supertrait requirements.

--- a/src/local_register.rs
+++ b/src/local_register.rs
@@ -31,12 +31,12 @@ use crate::{RegisterLongName, UIntLike};
 /// [`Writeable`](crate::interfaces::Writeable) and
 /// [`ReadWriteable`](crate::interfaces::ReadWriteable).
 #[derive(Copy, Clone)]
-pub struct LocalRegisterCopy<T: UIntLike, R: RegisterLongName = ()> {
+pub struct LocalRegisterCopy<T: Copy, R: RegisterLongName = ()> {
     value: T,
     associated_register: PhantomData<R>,
 }
 
-impl<T: UIntLike, R: RegisterLongName> LocalRegisterCopy<T, R> {
+impl<T: Copy, R: RegisterLongName> LocalRegisterCopy<T, R> {
     pub const fn new(value: T) -> Self {
         LocalRegisterCopy {
             value,
@@ -55,7 +55,9 @@ impl<T: UIntLike, R: RegisterLongName> LocalRegisterCopy<T, R> {
     pub fn set(&mut self, value: T) {
         self.value = value;
     }
+}
 
+impl<T: UIntLike, R: RegisterLongName> LocalRegisterCopy<T, R> {
     /// Read the value of the given field
     #[inline]
     pub fn read(&self, field: Field<T, R>) -> T {
@@ -130,7 +132,7 @@ impl<T: UIntLike, R: RegisterLongName> LocalRegisterCopy<T, R> {
     }
 }
 
-impl<T: UIntLike + fmt::Debug, R: RegisterLongName> fmt::Debug for LocalRegisterCopy<T, R> {
+impl<T: Copy + fmt::Debug, R: RegisterLongName> fmt::Debug for LocalRegisterCopy<T, R> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self.value)
     }


### PR DESCRIPTION
`DataType` is a trait that combines the primitive value type of the register and its bitfield type. It allows for `register_map!` to take only a single type for each register, rather than requiring the primitive type and bitfield type to be listed separately.

One change this makes is `UIntLike` is no longer the trait used for *all* register primitive types. This allows us to support pointer-typed registers (such as `CapabilityPtr`). We may not plan to use this in Tock, but it's still something we should support for other users of tock-registers. This changes `LocalRegisterCopy` accordingly.

I also reordered the module imports in `src/lib.rs` into alphabetical order, because I'm planning to add many modules in the future and I should have some way of organizing them.

AI use: none