### PR TITLE
Create the `tock-registers-codegen` crate.

### DIFF
--- a/.lcignore
+++ b/.lcignore
@@ -6,4 +6,6 @@
 /CHANGELOG.md
 /LICENSE-APACHE
 /LICENSE-MIT
-/README.md
+
+# Files that do not support comments.
+*.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,21 +2,45 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright Tock Contributors 2022.
 
-[package]
-name = "tock-registers"
+[workspace]
+members = [
+    "codegen",
+]
+
+[workspace.package]
 version = "0.10.1"
 authors = ["Tock Project Developers <devel@lists.tockos.org>"]
-description = "Memory-Mapped I/O and register interface developed for Tock."
 homepage = "https://www.tockos.org/"
 repository = "https://github.com/tock/tock-registers"
 readme = "README.md"
-keywords = ["tock", "embedded", "registers", "mmio", "bare-metal"]
-categories = ["data-structures", "embedded", "no-std"]
 license = "MIT/Apache-2.0"
 edition = "2021"
 # This must be kept in sync with rust-toolchain.toml; please see that file for
 # more information.
 rust-version = "1.82"
+
+[workspace.dependencies]
+proc-macro2 = { default-features = false, version = "1.0.106" }
+quote = { default-features = false, version = "1.0.45" }
+tock-registers-codegen = { path = "codegen", version = "=0.10.1" }
+
+[workspace.dependencies.syn]
+default-features = false
+features = ["clone-impls", "derive", "parsing", "printing"]
+version = "2.0.117"
+
+[package]
+name = "tock-registers"
+version.workspace = true
+authors.workspace = true
+categories = ["data-structures", "embedded", "no-std"]
+description = "Memory-Mapped I/O and register interface developed for Tock."
+edition.workspace = true
+homepage.workspace = true
+keywords = ["tock", "embedded", "registers", "mmio", "bare-metal"]
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 
 [features]
 default = [ "register_types" ]

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,35 @@
 # Copyright Tock Contributors 2026.
 
 .PHONY: test
-test:
-	+RUSTFLAGS="-D warnings" cargo build --all-targets --no-default-features
-	+RUSTFLAGS="-D warnings" cargo build --all-targets
-	+RUSTFLAGS="-D warnings" cargo test
+test: miri_test basic_test
+	@printf '%s%s\n%s\n%s%s\n' "$$(tput bold)" \
+		'*********************' \
+		'* Tests all passed! *' \
+		'*********************' "$$(tput sgr0)"
+
+# Rustup currently lacks the locking needed for concurrent use:
+# https://github.com/rust-lang/rustup/issues/988. In particular, running
+# concurrent cargo commands with a missing toolchain results in parallel rustup
+# instances installing the same toolchain, corrupting that toolchain. To
+# mitigate that issue, every target that uses the main (MSRV) toolchain should
+# depend transitively on the `toolchain` target, so that the toolchain is
+# installed before it is invoked concurrently. Note that we don't need to do
+# this for the nightly toolchain because the nightly toolchain is only used by
+# the `miri_test` target, so this Makefile won't invoke it concurrently.
+.PHONY: toolchain
+toolchain:
+	cargo -V
+
+.PHONY: basic_test
+basic_test: toolchain
+	+RUSTFLAGS="-D warnings" cargo build --no-default-features
+	+RUSTFLAGS="-D warnings" cargo build --all-targets --workspace
+	+RUSTFLAGS="-D warnings" cargo test --all-targets --workspace
 	+RUSTFLAGS="-D warnings" cargo clippy --all --all-targets --workspace
-	+RUSTDOCFLAGS="-D warnings" cargo doc
-	+cargo fmt --check
-	+cd nightly && \
-		RUSTFLAGS="-D warnings" cargo miri test --manifest-path=../Cargo.toml
+	+RUSTDOCFLAGS="-D warnings" cargo doc --workspace
+	+cargo fmt --all --check
+
+.PHONY: miri_test
+miri_test:
+	+cd nightly && RUSTFLAGS="-D warnings" \
+		cargo miri test --all-targets --manifest-path=../Cargo.toml --workspace

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,0 +1,32 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2026.
+# Copyright Better Bytes 2026.
+
+[package]
+name = "tock-registers-codegen"
+version.workspace = true
+authors.workspace = true
+description = "Code generation library for tock-registers"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+
+[dependencies]
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true
+
+[dev-dependencies]
+pretty_assertions = "1.4.1"
+prettyplease = "0.2.37"
+tock-registers = { path = ".." }
+
+[dev-dependencies.syn]
+features = ["extra-traits"]
+workspace = true
+
+[features]
+proc-macro = ["proc-macro2/proc-macro"]

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -1,0 +1,14 @@
+# `tock-registers-codegen` crate
+
+[`tock-registers-macros`](../macros) is the procedural macro crate for
+tock-registers. This crate, `tock-registers-codegen`, is a library crate that
+contains the implementation of tock-registers' procedural macros.
+
+Projects can use this crate to run the logic of tock-registers' procedural
+macros in a context other than a procedural macro. For example, the [macro
+expansion tool](../expand_macros) uses this crate to implement the code
+expansion.
+
+Note that the generated code is not stable; the version of the
+`tock-registers-codegen` crate must exactly match the version of the
+`tock-registers` crate that the generated code is compiled against.

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -12,3 +12,18 @@ expansion.
 Note that the generated code is not stable; the version of the
 `tock-registers-codegen` crate must exactly match the version of the
 `tock-registers` crate that the generated code is compiled against.
+
+## Dependency tree
+
+```
+$ cargo tree -e no-dev
+tock-registers-codegen v0.10.1 (/home/ryan/tock/registers/codegen)
+├── proc-macro2 v1.0.106
+│   └── unicode-ident v1.0.24
+├── quote v1.0.45
+│   └── proc-macro2 v1.0.106 (*)
+└── syn v2.0.117
+    ├── proc-macro2 v1.0.106 (*)
+    ├── quote v1.0.45 (*)
+    └── unicode-ident v1.0.24
+```

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -1,0 +1,60 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+// Copyright Better Bytes 2026.
+
+// If you're new to this macro's codebase, look at:
+// 1. The `ast` module. The rustdoc contains an explanation of the input grammar, and understanding
+//    the AST is important for understanding both the parsing module and the code generation
+//    modules.
+// 2. The generated code in `single_test_scalar`, then `single_test_array`, then
+//    `block_test_all_fields`. Nonobvious parts of the generated code are documented in those test
+//    cases.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+
+/// Returns the generated code for a `tock_registers_macro::register_map!` invocation.
+///
+/// # Input
+/// `tock_registers::register_map!` prepends `$crate` to the tokens passed to
+/// `tock_registers_macro::register_map!`, so that the generated code knows how to find the
+/// `tock_registers` crate. Therefore, this function needs `input` to start with the path to the
+/// `tock_registers` crate.
+///
+/// # Return value
+/// If an error is encountered, Err() is returned and the contained TokenStream produces a compiler
+/// error.
+pub fn register_map(input: TokenStream, env: Env) -> Result<TokenStream, TokenStream> {
+    let _ = (input, env);
+    todo!()
+}
+
+/// register_map generates slightly different code (different `#![allow()]` attributes) depending
+/// on whether it is run as part of a procedural macro or run externally to rustc. This enum is
+/// used to tell register_map which mode to use.
+#[derive(Clone, Copy)]
+pub enum Env {
+    /// Generate code suitable to feed into a separate rustc invocation run.
+    External,
+    /// Generate code tuned for procedural macros.
+    ProcMacro,
+}
+
+/// Returns the block comment for the `new` function for a register or register block.
+#[allow(unused)] // TODO: Remove once register_definition has been added (as part of the AST PR)
+fn new_doc_comment() -> TokenStream {
+    quote! {
+        /// Constructs an accessor for this register or register block.
+        /// # Safety
+        /// 1. `address` must point to register(s) on the bus corresponding to
+        ///    `B`.
+        /// 2. The register(s)' definition (as provided to the
+        ///    `tock_registers::register_map!` macro) must correctly
+        ///    describe the pointed-to register(s).
+        /// 3. The returned register accessor must not be used in a way that
+        ///    causes data races. The exact requirements depend on the hardware,
+        ///    but it's usually best to access a register from only one thread
+        ///    at a time.
+    }
+}


### PR DESCRIPTION
`tock-registers-codegen` will be the core of the procedural macro implementation; it will contain the AST, parsing logic, and code generation logic. However, the actual `proc-macro = true` crate will be a separate crate, not added in this PR, to support users who want to be able to build without depending on the `syn`/`quote`/`proc-macro2` crates.

This adds a bit of the implementation in `lib.rs`, but most of the implementation will come in later PRs.

I made the root `Cargo.toml` into a workspace and modified the Makefile to run the tests against all the crates. I changed the Miri test to run in parallel with the non-Miri tests, and added a toolchain initialization action to support expand_macros_test (which will come in a later PR). This parallelization is to keep the runtime of `make -j# test` reasonable once all of `register_map!` has been merged.

AI use: none