### PR TITLE
Add the register_map AST.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ basic_test: toolchain
 	+RUSTFLAGS="-D warnings" cargo build --no-default-features
 	+RUSTFLAGS="-D warnings" cargo build --all-targets --workspace
 	+RUSTFLAGS="-D warnings" cargo test --all-targets --workspace
+	+RUSTFLAGS="-D warnings" cargo test --doc --workspace
 	+RUSTFLAGS="-D warnings" cargo clippy --all --all-targets --workspace
 	+RUSTDOCFLAGS="-D warnings" cargo doc --workspace
 	+cargo fmt --all --check

--- a/codegen/src/ast.rs
+++ b/codegen/src/ast.rs
@@ -14,9 +14,10 @@ use quote::quote;
 use std::{ops::Index, slice};
 use syn::{Attribute, Ident, LitInt, Path, Type, TypePath, Visibility};
 
-/// Represents the full input to the register_map! procedural macro. Note that
-/// `tock_registers::register_map!` prepends `$crate` to the input provided by the user, so that
-/// the generated code can refer to tock_registers even if the user has renamed the crate.
+/// Represents the full input to the register_map! procedural macro.
+///
+/// Note that `tock_registers::register_map!` prepends `$crate` to the input provided by the user,
+/// so that the generated code can refer to tock_registers even if the user has renamed the crate.
 /// Therefore, after `tock_registers::register_map!` is expanded, the full input looks like:
 ///
 /// ```ignore
@@ -117,8 +118,10 @@ impl BusAttr {
     }
 }
 
-/// The part of a register that begins after the register's name. For individual register
-/// layouts, this starts with the colon, and in register blocks this begins with the opening brace.
+/// The part of a register that begins after the register's name.
+///
+/// For individual register layouts, this starts with the colon, and in register blocks this begins
+/// with the opening brace.
 ///
 /// ```ignore
 /// # use tock_registers::{Read, Write};

--- a/codegen/src/ast.rs
+++ b/codegen/src/ast.rs
@@ -1,0 +1,303 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+// Copyright Better Bytes 2026.
+
+//! The Abstract Syntax Tree for a register_map! invocation.
+
+#![allow(unused)] // TODO: Remove once code generation (block, single) is merged.
+
+// TODO: Remove `ignore` from the doc tests once the macros and Read/Write ops have been merged.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use std::{ops::Index, slice};
+use syn::{Attribute, Ident, LitInt, Path, Type, TypePath, Visibility};
+
+/// Represents the full input to the register_map! procedural macro. Note that
+/// `tock_registers::register_map!` prepends `$crate` to the input provided by the user, so that
+/// the generated code can refer to tock_registers even if the user has renamed the crate.
+/// Therefore, after `tock_registers::register_map!` is expanded, the full input looks like:
+///
+/// ```ignore
+/// # use tock_registers::{Mmio32, Read, Write};
+/// # fn main() {}
+/// tock_registers::internal::register_map! {
+///     ::tock_registers             // The prepended $crate
+///     //! Global doc comment       // This doc comment should attach to everything in the macro.
+///     #![buses(Mmio32)]            // Global buses attribute
+///     a: u8 { Read, Write },       // A register defined by primitive type and operation list
+///     /// Doc comment              // Doc comment that should attach to `b`
+///     pub b: [a; 2],               // A register array that refers to another definition
+///     /// Doc comment              // Doc comment that should attach to `foo`
+///     pub foo {                    // Start of a register block
+///         0 => c: u8 { Read },     // Field register defined by primitive type and operation list
+///         1 => _: 1,               // Padding of size 1 byte
+///         2 => d: a,               // Field register that refers to another definition
+///         /// Doc comment          // Doc comment that should attach to `e`
+///         3 => e: [b; 2],          // Field array register that contains another definition
+///     }
+/// }
+/// ```
+#[cfg_attr(test, derive(Debug))]
+pub struct Input {
+    /// The $crate passed in by the register_map! macro_rules macro (used to refer to the
+    /// tock_registers crate).
+    pub tock_registers: Path,
+    pub layouts: Vec<Layout>,
+}
+
+/// An individual register or register block layout.
+///
+/// ```ignore
+/// # use tock_registers::{Read, Write};
+/// # fn main() {}
+/// tock_registers::mmio32_register_map! {
+///     // `a` is a Layout
+///     a: u8 { Read, Write },
+///
+///     // `b` is a Layout, and it includes the doc comment before it.
+///     /// Doc comment
+///     pub b: [a; 2],
+///
+///     // `foo` is a Layout, and it includes the doc comment and attributes before it.
+///     /// Doc comment
+///     pub foo {
+///         0 => c: u8 { Read },  // Individual fields are `Field`s, not Layouts
+///         1 => _: 1,
+///         2 => d: a,
+///         3 => e: [b; 2],
+///     }
+/// }
+/// ```
+///
+/// When a Layout is parsed, if no `#[bus]` or `#[buses]` attribute is present, `bus` will be set
+/// to `BusAttr::Buses(vec![])`. The Parse impl for `Input` will correct the `bus` entry.
+#[cfg_attr(test, derive(Debug))]
+pub struct Layout {
+    /// Doc comments, converted into outer attributes.
+    pub docs: Vec<Attribute>,
+    pub bus: BusAttr,
+    pub visibility: Visibility,
+    pub name: Ident,
+    pub value: Value,
+}
+
+/// The `#[bus]` or `#[buses]` attribute for a layout.
+#[cfg_attr(test, derive(Debug, PartialEq))]
+#[derive(Clone)]
+pub enum BusAttr {
+    Bus(TypePath),
+    Buses(Vec<TypePath>),
+}
+
+impl BusAttr {
+    pub fn as_slice(&self) -> &[TypePath] {
+        match self {
+            BusAttr::Bus(bus) => slice::from_ref(bus),
+            BusAttr::Buses(buses) => buses,
+        }
+    }
+
+    /// Returns the `= <Bus>` default type for the `B: Bus` argument on a real struct, or an empty
+    /// stream if there is no such bound.
+    pub fn generic_default(&self) -> TokenStream {
+        match self {
+            BusAttr::Bus(bus) => quote![= #bus],
+            BusAttr::Buses(_) => TokenStream::new(),
+        }
+    }
+
+    /// Returns the number of buses.
+    pub fn len(&self) -> usize {
+        match self {
+            BusAttr::Bus(_) => 1,
+            BusAttr::Buses(buses) => buses.len(),
+        }
+    }
+}
+
+/// The part of a register that begins after the register's name. For individual register
+/// layouts, this starts with the colon, and in register blocks this begins with the opening brace.
+///
+/// ```ignore
+/// # use tock_registers::{Read, Write};
+/// # fn main() {}
+/// tock_registers::mmio32_register_map! {
+///     aa: u8 { Read, Write },
+///     //^^^^^^^^^^^^^^^^^^^^ Value::Single
+///
+///     /// Doc comment
+///     pub b: [aa; 2],
+///     //   ^^^^^^^^ Value::Single
+///
+///     /// Doc comment
+///     pub foo {
+///     //      ^  The Value::Block starts here, and continues through the final }
+///         0 => c: u8 { Read },
+///         1 => _: 1,
+///         2 => d: aa,
+///         3 => e: [b; 2],
+///     }
+/// }
+/// ```
+#[cfg_attr(test, derive(Debug))]
+pub enum Value {
+    Block(Vec<Field>),
+    Single(RegisterSpec),
+}
+
+/// An individual field in a register block. A Field can be padding or a register.
+///
+/// ```ignore
+/// # use tock_registers::{Read, Write};
+/// # fn main() {}
+/// tock_registers::mmio32_register_map! {
+///     a: u8 { Read, Write },
+///
+///     pub foo {
+///         0 => c: u8 { Read },
+///       //^^^^^^^^^^^^^^^^^^^ Field
+///
+///         1 => _: 1,
+///       //^^^^^^^^ Field (padding)
+///
+///         #[aliased] 2 => d: a,
+///       //^^^^^^^^^^^^^^^^^^^^ Field
+///
+///         // The doc comment is also part of the field
+///         /// Doc comment
+///         2 => f: [a; 256],
+///     }
+/// }
+/// ```
+#[cfg_attr(test, derive(Debug, PartialEq))]
+pub struct Field {
+    pub offsets: PerBusInt,
+    pub field_def: FieldDef,
+}
+
+/// Contents of a field.
+///
+/// Note that when a FieldDef::Register is initially parsed, `aliased` is always false and `docs`
+/// is always empty. The Parse impl on Field sets those fields.
+///
+/// ```ignore
+/// # use tock_registers::Read;
+/// # fn main() {}
+/// tock_registers::mmio32_register_map! {
+///     status: u8 { Read },
+///
+///     foo {
+///         0 => c: u8 { Read },
+///         //   ^^^^^^^^^^^^^^ FieldDef::Register
+///
+///         1 => _,
+///         //   ^ FieldDef::Padding
+///
+///         2 => d: status,
+///         //   ^^^^^^^^^ FieldDef::Register
+///
+///         3 => _: 1,
+///         //   ^^^^ FieldDef::Padding
+///     }
+/// }
+/// ```
+#[cfg_attr(test, derive(Debug, PartialEq))]
+pub enum FieldDef {
+    Padding(Option<PerBusInt>),
+    Register {
+        /// Doc comments for this register.
+        docs: Vec<Attribute>,
+        aliased: bool,
+        name: Ident,
+        spec: RegisterSpec,
+    },
+}
+
+/// Per-bus integer literal. Used for both field offsets and padding sizes. This can be a single
+/// value, which applies to all buses, or an array of values. The number of values in the array
+/// must match the number of buses.
+///
+/// ```ignore
+/// # use tock_registers::{Mmio32, Mmio64, Read, Write};
+/// # fn main() {}
+/// tock_registers::register_map! {
+///     #[buses(Mmio32, Mmio64)]
+///     foo {
+///         0 => c: u8 { Read },
+///       //^ PerBusInt::Single
+///
+///       //v PerBusInt::Single
+///         1 => _: 1,
+///       //        ^ PerBusInt::Single
+///
+///         2 => d: usize { Read, Write },
+///       //^ PerBusInt::Single
+///
+///         [6, 10] => e: u8 { Read },
+///       //^^^^^^^ PerBusInt::Array
+///
+///       //vvvvvvv PerBusInt::Array
+///         [7, 11] => _: [4, 0],
+///       //              ^^^^^^ PerBusInt::Array
+///     }
+/// }
+/// ```
+#[cfg_attr(test, derive(Debug, PartialEq))]
+pub enum PerBusInt {
+    Array(Vec<LitInt>),
+    Single(LitInt),
+}
+
+impl Index<usize> for PerBusInt {
+    type Output = LitInt;
+    fn index(&self, index: usize) -> &LitInt {
+        match self {
+            PerBusInt::Array(vec) => &vec[index],
+            PerBusInt::Single(int) => int,
+        }
+    }
+}
+
+/// A single register specification. A register specification can appear in two places: as its own
+/// top-level layout or as a field within a register block. The specification can either be an
+/// inline register definition (specifies the register's DataType and operations) or a register
+/// reference (whic refers to a register definition elsewhere). The RegisterSpec begins immediately
+/// after the register's name (i.e. it includes the ':').
+///
+/// ```ignore
+/// # use tock_registers::{Read, Write};
+/// # fn main() {}
+/// tock_registers::mmio32_register_map! {
+///     pub pin: u8 { Read, Write },
+///     //     ^^^^^^^^^^^^^^^^^^^^ Top-level RegisterSpec defining a new register
+///     pub pin_pair: [pin; 2],
+///     //          ^^^^^^^^^^ Top-level RegisterSpec referencing a separate definition (`status`)
+///     pub foo {
+///         0x0 => ctrl: u8 { Read, Write },
+///         //         ^^^^^^^^^^^^^^^^^^^^ Field RegisterSpec defining a new register
+///
+///         0x1 => _: 1,  // Padding is NOT a RegisterSpec
+///
+///         0x2 => pins: [pin; 2],
+///         //         ^^^^^^^^^^ RegisterSpec referencing a separate definition
+///     }
+/// }
+/// ```
+#[cfg_attr(test, derive(Debug, PartialEq))]
+pub struct RegisterSpec {
+    /// element_type can be a primitive type (for register definitions with operation lists) or a
+    /// path to another register definition (for register references). If the register type
+    /// specification is an array, this is the innermost type (i.e. element_type does not mention
+    /// that it is an array).
+    pub element_type: Type,
+    /// The array sizes. If this register specification is a nested array, the sizes are listed
+    /// from the innermost array to the outermost. For example, `[[[u8; 2]; 3]; 4]` would have
+    /// sizes list `[2, 3, 4]`.
+    pub array_sizes: Vec<LitInt>,
+
+    /// Operations, if this is a register definition. If this is a register reference, this will be
+    /// None.
+    pub operations: Option<Vec<Path>>,
+}

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -11,8 +11,13 @@
 //    `block_test_all_fields`. Nonobvious parts of the generated code are documented in those test
 //    cases.
 
+mod ast;
+
+use ast::RegisterSpec;
 use proc_macro2::TokenStream;
 use quote::quote;
+use std::mem::replace;
+use syn::{Ident, Path, PathArguments};
 
 /// Returns the generated code for a `tock_registers_macro::register_map!` invocation.
 ///
@@ -41,8 +46,55 @@ pub enum Env {
     ProcMacro,
 }
 
+/// Generates the Real struct for a register definition (one that has an operations list).
+/// `struct_name` is the name of the struct to generate, which does not need to match the name of
+/// the register.
+#[allow(unused)] // TODO: Remove when code generation is implemented.
+fn register_definition(
+    tock_registers: &Path,
+    docs: TokenStream,
+    bus_default: &TokenStream,
+    struct_name: &Ident,
+    register: &RegisterSpec,
+    operations: &[Path],
+) -> TokenStream {
+    let new_comment = new_doc_comment();
+    let element_type = &register.element_type;
+    let mut op_macros = Vec::with_capacity(operations.len());
+    let mut op_generics = Vec::with_capacity(operations.len());
+    for mut path in operations.iter().cloned() {
+        let last = path.segments.last_mut().expect("empty operation path");
+        op_generics.push(replace(&mut last.arguments, PathArguments::None));
+        op_macros.push(path);
+    }
+    quote! {
+        #docs #[derive(Clone)] pub struct #struct_name<B: Bus #bus_default> {
+            address: B,
+            _phantom: #tock_registers::internal::RealPhantom,
+        }
+        impl<B: Bus> #struct_name<B> {
+            #new_comment pub const unsafe fn new(address: B) -> Self {
+                Self { address, _phantom: #tock_registers::internal::RealPhantom::new() }
+            }
+        }
+        impl<B: Bus> #tock_registers::internal::core::marker::Copy for #struct_name<B> {}
+        // Safety: DataTypeBus' safety invariant requires PADDED_SIZE to be correct.
+        unsafe impl<B: Bus> #tock_registers::Span for #struct_name<B> {
+            type Address = B;
+            const SIZE: usize = <B as #tock_registers::DataTypeBus<#element_type>>::PADDED_SIZE;
+            unsafe fn with_addr(address: B) -> Self {
+                Self { address, _phantom: #tock_registers::internal::RealPhantom::new()  }
+            }
+            type Borrowed<'b> = #struct_name<#tock_registers::BorrowedBus<'b, B>>;
+        }
+        impl<B: Bus> #tock_registers::Register for #struct_name<B> {
+            type DataType = #element_type;
+        }
+        #(#op_macros!(real_impl, #struct_name, #element_type, #op_generics,);)*
+    }
+}
+
 /// Returns the block comment for the `new` function for a register or register block.
-#[allow(unused)] // TODO: Remove once register_definition has been added (as part of the AST PR)
 fn new_doc_comment() -> TokenStream {
     quote! {
         /// Constructs an accessor for this register or register block.

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -46,9 +46,9 @@ pub enum Env {
     ProcMacro,
 }
 
-/// Generates the Real struct for a register definition (one that has an operations list).
-/// `struct_name` is the name of the struct to generate, which does not need to match the name of
-/// the register.
+/// Generates the register accessor struct for a single register definition or register definition
+/// field. `struct_name` is the name of the struct to generate, which does not need to match the
+/// name of the register.
 #[allow(unused)] // TODO: Remove when code generation is implemented.
 fn register_definition(
     tock_registers: &Path,


### PR DESCRIPTION
This also adds the register_definition function, which will be used by the single and block code generation logic. I added a `cargo test --doc --workspace` invocation into `make test` because apparently `cargo test --all-targets` does not run doc tests.