### PR TITLE
Add the tock-registers-macros crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@
 
 [workspace]
 members = [
-    "codegen",
 ]
 
 [workspace.package]
@@ -42,8 +41,18 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 
+[dependencies.tock-registers-macros]
+optional = true
+path = "macros"
+version = "=0.10.1"
+
 [features]
-default = [ "register_types" ]
+default = ["proc_macros", "register_types"]
+
+# Includes the tock-registers-macros crate, which provides tock-registers'
+# procedural macros. Note that macros may also require the register_types
+# feature.
+proc_macros = ["dep:tock-registers-macros"]
 
 # Include actual register types (except LocalRegisterCopy). Disabling
 # the feature makes this an interface-only library and removes all

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,0 +1,26 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2026.
+# Copyright Better Bytes 2026.
+
+[package]
+name = "tock-registers-macros"
+version.workspace = true
+authors.workspace = true
+description = "Proc macros for tock-registers"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+
+[lib]
+proc-macro = true
+
+# Note: This crate purposely does not depend on `syn`. If too many crates in
+# this workspace depend on `syn`, then it becomes difficult to determine which
+# `syn` features should be enabled for each crate. This is especially true for
+# tock-registers-codegen, as its tests depend indirectly on this crate, and
+# codegen's tests have their own `syn` feature requirements.
+[dependencies]
+tock-registers-codegen = { features = ["proc-macro"], workspace = true }

--- a/macros/README.md
+++ b/macros/README.md
@@ -1,0 +1,21 @@
+# `tock-registers-macros`
+
+This is the procedural macro crate for tock-registers. Most of the
+implementation of the procedural macros is in
+[`tock-registers-codegen`](../codegen), so this is really just a wrapper crate.
+
+## Dependency tree
+
+```
+$ cargo tree
+tock-registers-macros v0.10.1 (proc-macro) (/home/ryan/tock/registers/macros)
+└── tock-registers-codegen v0.10.1 (/home/ryan/tock/registers/codegen)
+    ├── proc-macro2 v1.0.106
+    │   └── unicode-ident v1.0.24
+    ├── quote v1.0.45
+    │   └── proc-macro2 v1.0.106 (*)
+    └── syn v2.0.117
+        ├── proc-macro2 v1.0.106 (*)
+        ├── quote v1.0.45 (*)
+        └── unicode-ident v1.0.24
+```

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,0 +1,12 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+// Copyright Better Bytes 2026.
+
+use tock_registers_codegen::Env::ProcMacro;
+
+#[proc_macro]
+pub fn register_map(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let (Ok(out) | Err(out)) = tock_registers_codegen::register_map(input.into(), ProcMacro);
+    out.into()
+}

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,0 +1,28 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2024.
+// Copyright Google LLC 2024.
+// Copyright Better Bytes 2026.
+
+//! Items used by macros that are not part of tock-registers' public interface. Not for use by
+//! outside crates (the contents of this module are not stable).
+
+#![doc(hidden)]
+
+use core::marker::PhantomData;
+
+/// It's possible for a crate that is not libcore to be named `core` in a calling crate. Re-export
+/// so register_map! can reliably find libcore.
+pub use core;
+#[cfg(feature = "proc_macros")]
+pub use tock_registers_macros::register_map;
+
+/// Phantom type to make Real structs !Send and !Sync.
+#[derive(Clone, Copy, Default)]
+pub struct RealPhantom(PhantomData<*mut ()>);
+
+impl RealPhantom {
+    pub const fn new() -> Self {
+        Self(PhantomData)
+    }
+}

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -17,7 +17,7 @@ pub use core;
 #[cfg(feature = "proc_macros")]
 pub use tock_registers_macros::register_map;
 
-/// Phantom type to make Real structs !Send and !Sync.
+/// Phantom type to make register accessor structs !Send and !Sync.
 #[derive(Clone, Copy, Default)]
 pub struct RealPhantom(PhantomData<*mut ()>);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ pub use data_type::{DataType, Register};
 pub mod debug;
 pub mod fields;
 pub mod interfaces;
+pub mod internal;
 
 mod local_register;
 pub use local_register::LocalRegisterCopy;


### PR DESCRIPTION
This also adds the `internal` module, which exports items that will be used by the generated code.