### PR TITLE
codegen: Add parsing logic.

### DIFF
--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -12,14 +12,17 @@
 //    cases.
 
 mod ast;
+mod parse;
+#[cfg(all(test, not(miri)))]
+mod parse_tests;
 #[cfg(all(test, not(miri)))]
 mod test_util;
 
-use ast::RegisterSpec;
+use ast::{Input, RegisterSpec, Value};
 use proc_macro2::TokenStream;
 use quote::quote;
 use std::mem::replace;
-use syn::{Ident, Path, PathArguments};
+use syn::{parse2, Ident, Path, PathArguments};
 
 /// Returns the generated code for a `tock_registers_macro::register_map!` invocation.
 ///
@@ -33,8 +36,17 @@ use syn::{Ident, Path, PathArguments};
 /// If an error is encountered, Err() is returned and the contained TokenStream produces a compiler
 /// error.
 pub fn register_map(input: TokenStream, env: Env) -> Result<TokenStream, TokenStream> {
-    let _ = (input, env);
-    todo!()
+    let _ = env; // TODO: Remove when code generation is implemented
+    use Value::{Block, Single};
+    let input: Input = parse2(input).map_err(|e| e.to_compile_error())?;
+    let mut out = TokenStream::new();
+    for layout in input.layouts {
+        out.extend(match &layout.value {
+            Block(_fields) => quote![],    // TODO: Implement block generation
+            Single(_register) => quote![], // TODO: Implement single generation
+        });
+    }
+    Ok(out)
 }
 
 /// register_map generates slightly different code (different `#![allow()]` attributes) depending

--- a/codegen/src/parse.rs
+++ b/codegen/src/parse.rs
@@ -1,0 +1,271 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+// Copyright Better Bytes 2026.
+
+//! Input parser. The best reference for what this does is the [ast] module, as the doc comment on
+//! each AST type shows that type's definition syntax.
+
+use crate::ast::{BusAttr, Field, FieldDef, Input, Layout, PerBusInt, RegisterSpec, Value};
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::spanned::Spanned;
+use syn::token::{Brace, Bracket};
+use syn::{braced, bracketed, AttrStyle, Attribute, Error, LitInt, Meta, Result, Token, Type};
+
+impl Parse for Input {
+    fn parse(input: ParseStream) -> Result<Input> {
+        let tock_registers = input.parse()?;
+        // Parse attributes that apply to all layouts.
+        let (docs, bus) = layout_attributes(Attribute::parse_inner(input)?)?;
+        let punctuated = Punctuated::<Layout, Token![,]>::parse_terminated(input)?;
+        let mut layouts = Vec::with_capacity(punctuated.len());
+        for mut layout in punctuated {
+            // Prepend the global (inner attribute) docs to each Layout's local (outer attribute)
+            // docs).
+            layout.docs = docs.iter().cloned().chain(layout.docs).collect();
+            // Combine the Layout's buses specification with the global buses specification.
+            if layout.bus.as_slice().is_empty() {
+                if bus.as_slice().is_empty() {
+                    return Err(Error::new(layout.name.span(), "no bus specified"));
+                }
+                layout.bus = bus.clone();
+            }
+            let Value::Block(fields) = &layout.value else {
+                layouts.push(layout);
+                continue;
+            };
+            for field in fields {
+                if let PerBusInt::Array(offsets) = &field.offsets {
+                    if offsets.len() != layout.bus.len() {
+                        return Err(Error::new(
+                            offsets[0].span(),
+                            format!(
+                                "number of offsets ({}) does not match number of buses ({})",
+                                offsets.len(),
+                                layout.bus.len()
+                            ),
+                        ));
+                    };
+                }
+                if let FieldDef::Padding(Some(PerBusInt::Array(sizes))) = &field.field_def {
+                    if sizes.len() != layout.bus.len() {
+                        return Err(Error::new(
+                            sizes[0].span(),
+                            format!(
+                                "number of sizes ({}) does not match number of buses ({})",
+                                sizes.len(),
+                                layout.bus.len()
+                            ),
+                        ));
+                    }
+                }
+            }
+            layouts.push(layout);
+        }
+        Ok(Input {
+            tock_registers,
+            layouts,
+        })
+    }
+}
+
+impl Parse for Layout {
+    fn parse(input: ParseStream) -> Result<Layout> {
+        let (docs, bus) = layout_attributes(Attribute::parse_outer(input)?)?;
+        Ok(Layout {
+            docs,
+            bus,
+            visibility: input.parse()?,
+            name: input.parse()?,
+            value: input.parse()?,
+        })
+    }
+}
+
+/// Parses attributes that belong on a Layout. If no `#[bus]` or `#[buses(...)]` is specified,
+/// returns an empty `BusAttr::Buses`. Doc comments are converted into outer attributes and the
+/// attributes are returned in order (docs, buses).
+fn layout_attributes(attributes: Vec<Attribute>) -> Result<(Vec<Attribute>, BusAttr)> {
+    let mut docs = Vec::new();
+    let mut bus: Option<Attribute> = None;
+    for mut attr in attributes {
+        attr.style = AttrStyle::Outer;
+        match attr.path() {
+            p if p.is_ident("doc") => docs.push(attr),
+            p if p.is_ident("bus") || p.is_ident("buses") => {
+                if let Some(prev_bus) = bus {
+                    let mut error = Error::new_spanned(attr, "multiple bus attributes");
+                    error.combine(Error::new_spanned(
+                        prev_bus,
+                        "note: bus already specified here",
+                    ));
+                    return Err(error);
+                }
+                bus = Some(attr);
+            }
+            p => return Err(Error::new(p.span(), "unknown attribute")),
+        }
+    }
+    let bus = match bus {
+        Some(bus) if bus.path().is_ident("bus") => BusAttr::Bus(bus.parse_args()?),
+        Some(buses) => {
+            let punctuated = buses.parse_args_with(Punctuated::<_, Token![,]>::parse_terminated)?;
+            if punctuated.is_empty() {
+                return Err(Error::new_spanned(buses, "buses list cannot be empty"));
+            }
+            BusAttr::Buses(punctuated.into_iter().collect())
+        }
+        None => BusAttr::Buses(Vec::new()),
+    };
+    Ok((docs, bus))
+}
+
+impl Parse for Value {
+    fn parse(input: ParseStream) -> Result<Value> {
+        // Distinguish between a single register and block by looking at the first token, which
+        // should be either : (single) or { (block).
+        if input.peek(Token![:]) {
+            return input.parse().map(Value::Single);
+        }
+        if !input.peek(Brace) {
+            return Err(input.error("expected one of: `:`, `{`"));
+        }
+        let fields;
+        braced!(fields in input);
+        let fields: Vec<Field> = Punctuated::<_, Token![,]>::parse_terminated(&fields)?
+            .into_iter()
+            .collect();
+        for field in fields.iter().rev() {
+            match field.field_def {
+                FieldDef::Padding(None) => {
+                    return Err(Error::new(
+                        field.offsets[0].span(),
+                        "last non-aliased field cannot be padding without a size",
+                    ))
+                }
+                FieldDef::Register { aliased: true, .. } => continue,
+                FieldDef::Padding(Some(_)) | FieldDef::Register { aliased: false, .. } => break,
+            }
+        }
+        Ok(Value::Block(fields))
+    }
+}
+
+impl Parse for Field {
+    fn parse(input: ParseStream) -> Result<Field> {
+        let mut aliased_attr: Option<Attribute> = None;
+        let mut doc_attrs = Vec::new();
+        for attr in Attribute::parse_outer(input)? {
+            match attr.path() {
+                p if p.is_ident("doc") => doc_attrs.push(attr),
+                p if p.is_ident("aliased") => {
+                    if let Some(prev) = aliased_attr {
+                        let mut error = Error::new_spanned(attr, "multiple #[aliased] attributes");
+                        error.combine(Error::new_spanned(
+                            prev,
+                            "note: aliased already specified here",
+                        ));
+                        return Err(error);
+                    }
+                    let Meta::Path(_) = attr.meta else {
+                        return Err(Error::new_spanned(attr, "#[aliased] cannot have arguments"));
+                    };
+                    aliased_attr = Some(attr);
+                }
+                p => return Err(Error::new(p.span(), "unknown attribute")),
+            }
+        }
+        let offsets = input.parse()?;
+        input.parse::<Token![=>]>()?;
+        let mut field_def = input.parse()?;
+        match field_def {
+            FieldDef::Padding(_) => {
+                if let Some(last) = doc_attrs.last() {
+                    return Err(Error::new(last.span(), "padding cannot have doc comments"));
+                }
+                if let Some(aliased) = aliased_attr {
+                    return Err(Error::new_spanned(aliased, "padding cannot be aliased"));
+                }
+            }
+            FieldDef::Register {
+                ref mut docs,
+                ref mut aliased,
+                ..
+            } => {
+                *docs = doc_attrs;
+                *aliased = aliased_attr.is_some();
+            }
+        }
+        Ok(Field { offsets, field_def })
+    }
+}
+
+impl Parse for FieldDef {
+    fn parse(input: ParseStream) -> Result<FieldDef> {
+        if input.peek(Token![_]) {
+            // The underscore tells us this field is padding.
+            input.parse::<Token![_]>()?;
+            if !input.peek(Token![:]) {
+                return Ok(FieldDef::Padding(None));
+            }
+            input.parse::<Token![:]>()?;
+            return Ok(FieldDef::Padding(Some(input.parse()?)));
+        }
+        Ok(FieldDef::Register {
+            docs: Vec::new(),
+            aliased: false,
+            name: input.parse()?,
+            spec: input.parse()?,
+        })
+    }
+}
+
+impl Parse for PerBusInt {
+    fn parse(input: ParseStream) -> Result<PerBusInt> {
+        if !input.peek(Bracket) {
+            return input.parse().map(PerBusInt::Single);
+        }
+        let contents;
+        bracketed!(contents in input);
+        let ints = Punctuated::<_, Token![,]>::parse_terminated(&contents)?;
+        if ints.is_empty() {
+            return Err(Error::new(contents.span(), "list cannot be empty"));
+        }
+        Ok(PerBusInt::Array(ints.into_iter().collect()))
+    }
+}
+
+impl Parse for RegisterSpec {
+    fn parse(input: ParseStream) -> Result<RegisterSpec> {
+        input.parse::<Token![:]>()?;
+        // Recursive function to parse the type specification (because syn makes it hard to consume
+        // individual bracket tokens).
+        fn parse_type(input: ParseStream, array_sizes: &mut Vec<LitInt>) -> Result<Type> {
+            if !input.peek(Bracket) {
+                return input.parse();
+            }
+            let inner;
+            bracketed!(inner in input);
+            let out = parse_type(&inner, array_sizes)?;
+            inner.parse::<Token![;]>()?;
+            array_sizes.push(inner.parse()?);
+            Ok(out)
+        }
+        let mut array_sizes = Vec::new();
+        let element_type = parse_type(input, &mut array_sizes)?;
+        let operations = if input.peek(Brace) {
+            let ops;
+            braced!(ops in input);
+            let ops = Punctuated::<_, Token![,]>::parse_terminated(&ops)?;
+            Some(ops.into_iter().collect())
+        } else {
+            None
+        };
+        Ok(RegisterSpec {
+            element_type,
+            array_sizes,
+            operations,
+        })
+    }
+}

--- a/codegen/src/parse_tests.rs
+++ b/codegen/src/parse_tests.rs
@@ -1,0 +1,212 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+// Copyright Better Bytes 2026.
+
+use crate::ast::{Field, FieldDef, Input, PerBusInt, RegisterSpec};
+use quote::quote;
+use syn::{parse2, parse_quote, Type};
+
+// Verifies that outer and inner #[bus] and #[buses] attributes are combined correctly.
+#[test]
+fn bus() {
+    use crate::ast::BusAttr::{Bus, Buses};
+
+    let error = parse2::<Input>(quote![::tock_registers b: a]).unwrap_err();
+    assert!(error.to_string().contains("no bus specified"));
+
+    // Shortcuts so the assert_eq!() calls don't line-wrap.
+    let mmio32 = || parse_quote![Mmio32];
+    let mmio64 = || parse_quote![Mmio64];
+    let mmio32null = || parse_quote![Mmio32Nullable];
+
+    let input: Input = parse_quote! {
+        ::tock_registers
+        #[bus(Mmio32)] a: r,
+        #[buses(Mmio32)] b: r,
+        #[buses(Mmio32, Mmio64)] c: r,
+    };
+    assert_eq!(input.layouts[0].bus, Bus(mmio32()));
+    assert_eq!(input.layouts[1].bus, Buses(vec![mmio32()]));
+    assert_eq!(input.layouts[2].bus, Buses(vec![mmio32(), mmio64()]));
+
+    let input: Input = parse_quote! {
+        ::tock_registers #![bus(Mmio32)]
+        a: r,
+        #[bus(Mmio64)] b: r,
+        #[buses(Mmio64)] c: r,
+        #[buses(Mmio32Nullable, Mmio64)] d: r,
+    };
+    assert_eq!(input.layouts[0].bus, Bus(mmio32()));
+    assert_eq!(input.layouts[1].bus, Bus(mmio64()));
+    assert_eq!(input.layouts[2].bus, Buses(vec![mmio64()]));
+    assert_eq!(input.layouts[3].bus, Buses(vec![mmio32null(), mmio64()]));
+
+    let input: Input = parse_quote! {
+        ::tock_registers #![buses(Mmio32)]
+        a: r,
+        #[bus(Mmio64)] b: r,
+        #[buses(Mmio64)] c: r,
+        #[buses(Mmio32Nullable, Mmio64)] d: r,
+    };
+    assert_eq!(input.layouts[0].bus, Buses(vec![mmio32()]));
+    assert_eq!(input.layouts[1].bus, Bus(mmio64()));
+    assert_eq!(input.layouts[2].bus, Buses(vec![mmio64()]));
+    assert_eq!(input.layouts[3].bus, Buses(vec![mmio32null(), mmio64()]));
+
+    let input: Input = parse_quote! {
+        ::tock_registers #![buses(Mmio32, Mmio32Nullable)]
+        a: r,
+        #[bus(Mmio64)] b: r,
+        #[buses(Mmio64)] c: r,
+        #[buses(Mmio32Nullable, Mmio64)] d: r,
+    };
+    assert_eq!(input.layouts[0].bus, Buses(vec![mmio32(), mmio32null()]));
+    assert_eq!(input.layouts[1].bus, Bus(mmio64()));
+    assert_eq!(input.layouts[2].bus, Buses(vec![mmio64()]));
+    assert_eq!(input.layouts[3].bus, Buses(vec![mmio32null(), mmio64()]));
+
+    let error = parse2::<Input>(quote![::tock_registers #![bus(A)] #![buses(B)] b: a]).unwrap_err();
+    assert!(error.to_string().contains("multiple bus attributes"));
+
+    let error = parse2::<Input>(quote![::tock_registers #[buses(A)] #[bus(B)] b: a]).unwrap_err();
+    assert!(error.to_string().contains("multiple bus attributes"));
+}
+
+// Verifies that an error is correctly returned if the number of offsets of a field or the number
+// of sizes for padding does not match the number of buses for that layout.
+#[test]
+fn bus_count_mismatches() {
+    let error =
+        parse2::<Input>(quote![::tock_registers #[bus(Port)] a { [0, 1] => a: u8 { Read } } ])
+            .unwrap_err()
+            .to_string();
+    assert!(error.contains("number of offsets (2) does not match number of buses (1)"));
+
+    let error =
+        parse2::<Input>(quote![::tock_registers #![buses(Mmio32, Port)] a { 0 => _: [1] } ])
+            .unwrap_err()
+            .to_string();
+    assert!(error.contains("number of sizes (1) does not match number of buses (2)"));
+}
+
+#[test]
+fn field() {
+    let field: Field = parse_quote! {
+        ///A
+        ///B
+        1 => a: b
+    };
+    assert_eq!(
+        field,
+        Field {
+            offsets: PerBusInt::Single(parse_quote![1]),
+            field_def: FieldDef::Register {
+                docs: vec![parse_quote![#[doc = r"A"]], parse_quote![#[doc = r"B"]]],
+                aliased: false,
+                name: parse_quote![a],
+                spec: RegisterSpec {
+                    element_type: parse_quote![b],
+                    array_sizes: vec![],
+                    operations: None,
+                },
+            },
+        },
+    );
+
+    let error = parse2::<Field>(quote![#[aliased] 1 => _: 2]).unwrap_err();
+    assert!(error.to_string().contains("padding cannot be aliased"));
+
+    let field: Field = parse_quote![1 => _: 2];
+    assert_eq!(
+        field,
+        Field {
+            offsets: PerBusInt::Single(parse_quote![1]),
+            field_def: FieldDef::Padding(Some(PerBusInt::Single(parse_quote![2])))
+        },
+    );
+
+    let field: Field = parse_quote![#[aliased] [1, 2] => a: u8 { Read }];
+    assert_eq!(
+        field,
+        Field {
+            offsets: PerBusInt::Array(vec![parse_quote![1], parse_quote![2]]),
+            field_def: FieldDef::Register {
+                docs: vec![],
+                aliased: true,
+                name: parse_quote![a],
+                spec: RegisterSpec {
+                    element_type: parse_quote![u8],
+                    array_sizes: vec![],
+                    operations: Some(vec![parse_quote![Read]]),
+                },
+            },
+        },
+    );
+
+    let error = parse2::<Field>(quote![#[aliased] #[aliased] 1 => a: status]).unwrap_err();
+    assert!(error.to_string().contains("multiple #[aliased] attributes"));
+
+    let error = parse2::<Field>(quote![#[aliased = 3] 1 => a: status]).unwrap_err();
+    assert!(error.to_string().contains("cannot have arguments"));
+
+    let error = parse2::<Field>(quote![#[aliased(3)] 1 => a: status]).unwrap_err();
+    assert!(error.to_string().contains("cannot have arguments"));
+}
+
+#[test]
+fn field_def() {
+    let field: FieldDef = parse_quote![_: 3];
+    assert_eq!(field, FieldDef::Padding(Some(parse_quote![3])));
+
+    let field: FieldDef = parse_quote![_];
+    assert_eq!(field, FieldDef::Padding(None));
+
+    let field: FieldDef = parse_quote![a: status];
+    assert_eq!(
+        field,
+        FieldDef::Register {
+            docs: vec![],
+            aliased: false,
+            name: parse_quote![a],
+            spec: RegisterSpec {
+                element_type: parse_quote![status],
+                array_sizes: vec![],
+                operations: None,
+            }
+        }
+    );
+}
+
+#[test]
+fn per_bus_int() {
+    let offsets: PerBusInt = parse_quote![0x0];
+    assert_eq!(offsets, PerBusInt::Single(parse_quote![0x0]));
+
+    let offsets: PerBusInt = parse_quote!([1, 2, 1]);
+    let expected = vec![parse_quote![1], parse_quote![2], parse_quote![1]];
+    assert_eq!(offsets, PerBusInt::Array(expected));
+}
+
+#[test]
+fn register_def() {
+    let register: RegisterSpec = parse_quote![: <Foo as Bar>::Associated { Read, Write }];
+    let expected_type: Type = parse_quote![<Foo as Bar>::Associated];
+    assert_eq!(register.element_type, expected_type);
+    assert_eq!(register.array_sizes, []);
+    let expected_operations = vec![parse_quote![Read], parse_quote![Write]];
+    assert_eq!(register.operations, Some(expected_operations));
+
+    let register: RegisterSpec = parse_quote![: status];
+    let expected_type: Type = parse_quote![status];
+    assert_eq!(register.element_type, expected_type);
+    assert_eq!(register.array_sizes, []);
+    assert_eq!(register.operations, None);
+
+    let register: RegisterSpec = parse_quote![: [[[*mut u8; 2]; 3]; 4]];
+    let expected_type: Type = parse_quote![*mut u8];
+    assert_eq!(register.element_type, expected_type);
+    let expected_sizes = [parse_quote![2], parse_quote![3], parse_quote![4]];
+    assert_eq!(register.array_sizes, expected_sizes);
+    assert_eq!(register.operations, None);
+}


### PR DESCRIPTION
This also sets up tock_registers_codegen::register_map so that register block and single register generation can be merged in separate PRs.