### PR TITLE
Add the safe register_map! operations: Read, Write, and ReadWrite.

### DIFF
--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -182,8 +182,6 @@ pub trait Readable {
         field.read(self.get())
     }
 
-    /// Set the raw register value
-    ///
     /// The [`register_bitfields!`](crate::register_bitfields) macro will
     /// generate an enum containing the various named field variants and
     /// implementing the required [`TryFromValue`] trait. It is accessible as

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,8 +81,18 @@ pub use local_register::LocalRegisterCopy;
 
 pub mod macros;
 
+mod read;
+#[cfg(feature = "register_types")]
+pub use read::BusRead;
+pub use read::Read;
+
 #[cfg(feature = "register_types")]
 pub mod registers;
+
+mod write;
+#[cfg(feature = "register_types")]
+pub use write::BusWrite;
+pub use write::{ReadWrite, Write};
 
 use core::fmt::Debug;
 use core::ops::{BitAnd, BitOr, BitOrAssign, Not, Shl, Shr};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ pub mod registers;
 mod write;
 #[cfg(feature = "register_types")]
 pub use write::BusWrite;
-pub use write::{ReadWrite, Write};
+pub use write::Write;
 
 use core::fmt::Debug;
 use core::ops::{BitAnd, BitOr, BitOrAssign, Not, Shl, Shr};

--- a/src/read.rs
+++ b/src/read.rs
@@ -26,7 +26,7 @@ pub trait Read: Register {
         field.read(self.get())
     }
 
-    /// Set the raw register value
+    /// Read value of the given field as an enum member
     ///
     /// The [`register_bitfields!`](crate::register_bitfields) macro will
     /// generate an enum containing the various named field variants and

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,0 +1,213 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+// Copyright Better Bytes 2026.
+
+use crate::debug::{RegisterDebugInfo, RegisterDebugValue};
+use crate::fields::{Field, FieldValue, TryFromValue};
+#[cfg(feature = "register_types")]
+use crate::{Address, BorrowedBus, Bus};
+use crate::{DataType, LocalRegisterCopy, Register, UIntLike};
+use core::marker::PhantomData;
+
+/// A register that can be read.
+pub trait Read: Register {
+    /// Get the raw register value
+    fn get(self) -> <Self::DataType as DataType>::Value;
+
+    /// Read the value of the given field
+    fn read(
+        self,
+        field: Field<<Self::DataType as DataType>::Value, <Self::DataType as DataType>::LongName>,
+    ) -> <Self::DataType as DataType>::Value
+    where
+        <Self::DataType as DataType>::Value: UIntLike,
+    {
+        field.read(self.get())
+    }
+
+    /// Set the raw register value
+    ///
+    /// The [`register_bitfields!`](crate::register_bitfields) macro will
+    /// generate an enum containing the various named field variants and
+    /// implementing the required [`TryFromValue`] trait. It is accessible as
+    /// `$REGISTER_NAME::$FIELD_NAME::Value`.
+    ///
+    /// This method can be useful to symbolically represent read register field
+    /// states throughout the codebase and to enforce exhaustive matches over
+    /// all defined valid register field values.
+    ///
+    /// ## Usage Example
+    ///
+    /// ```rust
+    /// # use tock_registers::interfaces::Readable;
+    /// # use tock_registers::registers::InMemoryRegister;
+    /// # use tock_registers::register_bitfields;
+    /// register_bitfields![u8,
+    ///     EXAMPLEREG [
+    ///         TESTFIELD OFFSET(0) NUMBITS(2) [
+    ///             Foo = 0,
+    ///             Bar = 1,
+    ///             Baz = 2,
+    ///         ],
+    ///     ],
+    /// ];
+    ///
+    /// let reg: InMemoryRegister<u8, EXAMPLEREG::Register> =
+    ///     InMemoryRegister::new(2);
+    ///
+    /// match reg.read_as_enum(EXAMPLEREG::TESTFIELD) {
+    ///     Some(EXAMPLEREG::TESTFIELD::Value::Foo) => "Tock",
+    ///     Some(EXAMPLEREG::TESTFIELD::Value::Bar) => "is",
+    ///     Some(EXAMPLEREG::TESTFIELD::Value::Baz) => "awesome!",
+    ///     None => panic!("boo!"),
+    /// };
+    /// ```
+    fn read_as_enum<E: TryFromValue<<Self::DataType as DataType>::Value, EnumType = E>>(
+        self,
+        field: Field<<Self::DataType as DataType>::Value, <Self::DataType as DataType>::LongName>,
+    ) -> Option<E>
+    where
+        <Self::DataType as DataType>::Value: UIntLike,
+    {
+        field.read_as_enum(self.get())
+    }
+
+    /// Make a local copy of the register
+    fn extract(
+        self,
+    ) -> LocalRegisterCopy<
+        <Self::DataType as DataType>::Value,
+        <Self::DataType as DataType>::LongName,
+    > {
+        LocalRegisterCopy::new(self.get())
+    }
+
+    /// Check if one or more bits in a field are set
+    fn is_set(
+        self,
+        field: Field<<Self::DataType as DataType>::Value, <Self::DataType as DataType>::LongName>,
+    ) -> bool
+    where
+        <Self::DataType as DataType>::Value: UIntLike,
+    {
+        field.is_set(self.get())
+    }
+
+    /// Check if any bits corresponding to the mask in the passed `FieldValue`
+    /// are set.  This function is identical to `is_set()` but operates on a
+    /// `FieldValue` rather than a `Field`, allowing for checking if any bits
+    /// are set across multiple, non-contiguous portions of a bitfield.
+    fn any_matching_bits_set(
+        self,
+        field: FieldValue<
+            <Self::DataType as DataType>::Value,
+            <Self::DataType as DataType>::LongName,
+        >,
+    ) -> bool
+    where
+        <Self::DataType as DataType>::Value: UIntLike,
+    {
+        field.any_matching_bits_set(self.get())
+    }
+
+    /// Check if all specified parts of a field match
+    fn matches_all(
+        self,
+        field: FieldValue<
+            <Self::DataType as DataType>::Value,
+            <Self::DataType as DataType>::LongName,
+        >,
+    ) -> bool
+    where
+        <Self::DataType as DataType>::Value: UIntLike,
+    {
+        field.matches_all(self.get())
+    }
+
+    /// Check if any of the passed parts of a field exactly match the contained
+    /// value. This allows for matching on unset bits, or matching on specific
+    /// values in multi-bit fields.
+    fn matches_any(
+        self,
+        fields: &[FieldValue<
+            <Self::DataType as DataType>::Value,
+            <Self::DataType as DataType>::LongName,
+        >],
+    ) -> bool
+    where
+        <Self::DataType as DataType>::Value: UIntLike,
+    {
+        let value = self.get();
+        fields
+            .iter()
+            .any(|field| value & field.mask() == field.value)
+    }
+
+    /// Returns a [`RegisterDebugValue`] that implements [`core::fmt::Debug`]. The debug
+    /// information is extracted from `<Register>::DebugInfo`.
+    fn debug(
+        self,
+    ) -> RegisterDebugValue<
+        <Self::DataType as DataType>::Value,
+        <Self::DataType as DataType>::LongName,
+    >
+    where
+        <Self::DataType as DataType>::Value: UIntLike,
+        <Self::DataType as DataType>::LongName:
+            RegisterDebugInfo<<Self::DataType as DataType>::Value>,
+    {
+        RegisterDebugValue {
+            data: self.get(),
+            _reg: PhantomData,
+        }
+    }
+}
+
+/// A Bus that implements `BusRead<T>` can support Read implementations with DataType T. Other
+/// crates (e.g. LiteX registers) can implement this on their own buses so that Read works with
+/// them as well.
+#[cfg(feature = "register_types")]
+pub trait BusRead<T>: Bus<T> {
+    /// # Safety
+    /// There must be a readable register of type T at `pointer`, and if the register itself has
+    /// safety invariants (i.e. it is `UnsafeRead`) the caller must satisfy those. The caller is
+    /// responsible for avoiding data races.
+    unsafe fn read(self) -> T;
+}
+
+#[cfg(feature = "register_types")]
+impl<'b, T, A: Address + BusRead<T>> BusRead<T> for BorrowedBus<'b, A> {
+    unsafe fn read(self) -> T {
+        // Safety: We are the same Bus as A, so the caller has already satisfied all the
+        // requirements of read.
+        unsafe { self.address().read() }
+    }
+}
+
+/// The macro that goes along with the Read trait. We don't expect this macro to be used by
+/// tock_register's users, instead it is invoked by the generated code.
+#[cfg(feature = "register_types")]
+#[macro_export]
+macro_rules! Read {
+    // Provides a real implementation of the trait. The trailing $rest argument is for future
+    // compatibility: it allows the procedural macro to pass additional arguments in the future
+    // without breaking compatibility with this implementation of Read!.
+    (real_impl, $name:ident, $datatype:ty, $($rest:tt)*) => {
+        impl<B: Bus + $crate::BusRead<<$datatype as $crate::DataType>::Value>> $crate::Read
+            for $name<B>
+        {
+            fn get(self) -> <$datatype as $crate::DataType>::Value {
+                // Safety: The caller assured this register accessor points at a register on bus B
+                // with value type $datatype::Value that is safe to read. The code that constructed
+                // `self` guaranteed that they would avoid data races (precondition of Self::new).
+                unsafe { self.address.read() }
+            }
+        }
+    };
+    // Catch-all case that emits nothing if register_map! invokes it with an unknown first
+    // argument. This is so that we can add new functionality into the operations macros without
+    // breaking backwards compatibility (though registers! would need to be compatible with this
+    // do-nothing block).
+    ($($unknown:tt)*) => {};
+}

--- a/src/write.rs
+++ b/src/write.rs
@@ -12,8 +12,7 @@ pub trait Write: Register {
     /// Set the raw register value
     fn set(self, value: <Self::DataType as DataType>::Value);
 
-    /// Write the value of one or more fields, overwriting the other fields with
-    /// zero
+    /// Write the value of one or more fields, overwriting the other fields with zero.
     fn write(
         &self,
         field: FieldValue<
@@ -24,6 +23,20 @@ pub trait Write: Register {
         <Self::DataType as DataType>::Value: UIntLike,
     {
         self.set(field.value);
+    }
+
+    /// Write the value of one or more fields, leaving the other fields unchanged.
+    fn modify(
+        &self,
+        field: FieldValue<
+            <Self::DataType as DataType>::Value,
+            <Self::DataType as DataType>::LongName,
+        >,
+    ) where
+        Self: Read,
+        <Self::DataType as DataType>::Value: UIntLike,
+    {
+        self.set(field.modify(self.get()));
     }
 
     /// Write the value of one or more fields, maintaining the value of
@@ -45,26 +58,6 @@ pub trait Write: Register {
         self.set(field.modify(original.get()));
     }
 }
-
-/// A register that can be read and written with the same RegisterLongName. This is automatically
-/// implemented for registers that are both Read and Write with the same RegisterLongName.
-pub trait ReadWrite: Read + Write {
-    /// Write the value of one or more fields, leaving the other fields
-    /// unchanged
-    fn modify(
-        &self,
-        field: FieldValue<
-            <Self::DataType as DataType>::Value,
-            <Self::DataType as DataType>::LongName,
-        >,
-    ) where
-        <Self::DataType as DataType>::Value: UIntLike,
-    {
-        self.set(field.modify(self.get()));
-    }
-}
-
-impl<R: Read + Write> ReadWrite for R {}
 
 /// A Bus that implements `BusWrite<T>` can support Write implementations with DataType T. Other
 /// crates (e.g. LiteX registers) can implement this on their own buses so that Write works with

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,0 +1,116 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022.
+// Copyright Better Bytes 2026.
+
+use crate::{fields::FieldValue, DataType, LocalRegisterCopy, Read, Register, UIntLike};
+#[cfg(feature = "register_types")]
+use crate::{Address, BorrowedBus, Bus};
+
+/// A register that can be written.
+pub trait Write: Register {
+    /// Set the raw register value
+    fn set(self, value: <Self::DataType as DataType>::Value);
+
+    /// Write the value of one or more fields, overwriting the other fields with
+    /// zero
+    fn write(
+        &self,
+        field: FieldValue<
+            <Self::DataType as DataType>::Value,
+            <Self::DataType as DataType>::LongName,
+        >,
+    ) where
+        <Self::DataType as DataType>::Value: UIntLike,
+    {
+        self.set(field.value);
+    }
+
+    /// Write the value of one or more fields, maintaining the value of
+    /// unchanged fields via a provided original value, rather than a register
+    /// read.
+    fn modify_no_read(
+        &self,
+        original: LocalRegisterCopy<
+            <Self::DataType as DataType>::Value,
+            <Self::DataType as DataType>::LongName,
+        >,
+        field: FieldValue<
+            <Self::DataType as DataType>::Value,
+            <Self::DataType as DataType>::LongName,
+        >,
+    ) where
+        <Self::DataType as DataType>::Value: UIntLike,
+    {
+        self.set(field.modify(original.get()));
+    }
+}
+
+/// A register that can be read and written with the same RegisterLongName. This is automatically
+/// implemented for registers that are both Read and Write with the same RegisterLongName.
+pub trait ReadWrite: Read + Write {
+    /// Write the value of one or more fields, leaving the other fields
+    /// unchanged
+    fn modify(
+        &self,
+        field: FieldValue<
+            <Self::DataType as DataType>::Value,
+            <Self::DataType as DataType>::LongName,
+        >,
+    ) where
+        <Self::DataType as DataType>::Value: UIntLike,
+    {
+        self.set(field.modify(self.get()));
+    }
+}
+
+impl<R: Read + Write> ReadWrite for R {}
+
+/// A Bus that implements `BusWrite<T>` can support Write implementations with DataType T. Other
+/// crates (e.g. LiteX registers) can implement this on their own buses so that Write works with
+/// them as well.
+#[cfg(feature = "register_types")]
+pub trait BusWrite<T>: Bus<T> {
+    /// # Safety
+    /// There must be a writable register of type T at `pointer`, and if the register itself has
+    /// safety invariants (i.e. it is `UnsafeWrite`) the caller must satisfy those. The caller is
+    /// responsible for avoiding data races.
+    unsafe fn write(self, value: T);
+}
+
+#[cfg(feature = "register_types")]
+impl<'b, T, A: Address + BusWrite<T>> BusWrite<T> for BorrowedBus<'b, A> {
+    unsafe fn write(self, value: T) {
+        // Safety: We are the same Bus as A, so the caller has already satisfied all the
+        // requirements of write.
+        unsafe { self.address().write(value) }
+    }
+}
+
+/// The macro that goes along with the Write trait. We don't expect this macro to be used by
+/// tock_register's users, instead it is invoked by the generated code.
+#[cfg(feature = "register_types")]
+#[macro_export]
+macro_rules! Write {
+    // Provides a real implementation of the trait. The trailing $rest argument is for future
+    // compatibility: it allows the procedural macro to pass additional arguments in the future
+    // without breaking compatibility with this implementation of Write!.
+    (real_impl, $name:ident, $datatype:ty, $($rest:tt)*) => {
+        impl<B: Bus + $crate::BusWrite<<$datatype as $crate::DataType>::Value>> $crate::Write
+            for $name<B>
+        {
+            fn set(self, value: <$datatype as $crate::DataType>::Value) {
+                // Safety: The caller assured this register accessor points at a register on bus B
+                // with value type $datatype::Value that is safe to write. The code that
+                // constructed `self` guaranteed that they would avoid data races (precondition of
+                // Self::new).
+                unsafe { self.address.write(value) }
+            }
+        }
+    };
+    // Catch-all case that emits nothing if register_map! invokes it with an unknown first
+    // argument. This is so that we can add new functionality into the operations traits without
+    // breaking backwards compatibility (though registers! would need to be compatible with this
+    // do-nothing block).
+    ($($unknown:tt)*) => {};
+}


### PR DESCRIPTION
These are the successors to the Readable, Writeable, and ReadWriteable traits for use with the `register_map!` macro.