### PR TITLE
Add code generation for single registers.

### DIFF
--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -15,6 +15,13 @@ mod ast;
 mod parse;
 #[cfg(all(test, not(miri)))]
 mod parse_tests;
+mod single;
+#[cfg(all(test, not(miri)))]
+mod single_test_array;
+#[cfg(all(test, not(miri)))]
+mod single_test_docs;
+#[cfg(all(test, not(miri)))]
+mod single_test_scalar;
 #[cfg(all(test, not(miri)))]
 mod test_util;
 
@@ -36,14 +43,15 @@ use syn::{parse2, Ident, Path, PathArguments};
 /// If an error is encountered, Err() is returned and the contained TokenStream produces a compiler
 /// error.
 pub fn register_map(input: TokenStream, env: Env) -> Result<TokenStream, TokenStream> {
-    let _ = env; // TODO: Remove when code generation is implemented
     use Value::{Block, Single};
     let input: Input = parse2(input).map_err(|e| e.to_compile_error())?;
     let mut out = TokenStream::new();
     for layout in input.layouts {
+        // TODO: Remove rustfmt::skip after block generation is merged.
+        #[rustfmt::skip]
         out.extend(match &layout.value {
             Block(_fields) => quote![],    // TODO: Implement block generation
-            Single(_register) => quote![], // TODO: Implement single generation
+            Single(register) => single::generate(env, &input.tock_registers, &layout, register),
         });
     }
     Ok(out)
@@ -63,7 +71,6 @@ pub enum Env {
 /// Generates the register accessor struct for a single register definition or register definition
 /// field. `struct_name` is the name of the struct to generate, which does not need to match the
 /// name of the register.
-#[allow(unused)] // TODO: Remove when code generation is implemented.
 fn register_definition(
     tock_registers: &Path,
     docs: TokenStream,

--- a/codegen/src/single.rs
+++ b/codegen/src/single.rs
@@ -1,0 +1,174 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+// Copyright Better Bytes 2026.
+
+use crate::ast::{Layout, RegisterSpec};
+use crate::{register_definition, Env};
+use proc_macro2::{Span, TokenStream};
+use quote::{quote, quote_spanned};
+use syn::{spanned::Spanned, Ident, Path};
+
+/// Generates the module for a single register definition.
+pub fn generate(
+    env: Env,
+    tock_registers: &Path,
+    layout: &Layout,
+    register: &RegisterSpec,
+) -> TokenStream {
+    // At a high level, this function has:
+    //
+    // 1. A set of variable declarations, mostly of type TokenStream
+    // 2. A series of loops/conditionals, each of which switch/iterate on a different aspect of the
+    //    layout.
+    // 3. A final quote! invocation that combines the variable declarations into the output code.
+    //
+    // This pattern avoids a lot of code duplication that would occur if we tried to generate each
+    // piece of the output module in sequence.
+    //
+    // When you're trying to understand this code, a good route is:
+    //
+    // 1. Finding the portion of the generated code you're interested in within scalar_test_basic
+    // 2. Tracing that portion of the generated code back through the final quote! invocation to
+    //    the variables that produced it.
+    // 3. Searching for uses of those variables to see how they are created.
+
+    // Step 1: variable declarations
+    let allows = match env {
+        Env::External => quote![#![allow(dead_code)]],
+        Env::ProcMacro => quote![],
+    };
+    let is_scalar = register.array_sizes.is_empty();
+    let is_definition = register.operations.is_some();
+    let element_type = &register.element_type;
+    let docs = &layout.docs;
+    let visibility = &layout.visibility;
+    let name = &layout.name;
+    let interface_comment = interface_doc_comment();
+    let element_bound;
+    let bus_comment = bus_doc_comment();
+    let bus_bound;
+    let buses = layout.bus.as_slice();
+    let element_definition;
+    let mut real;
+
+    // Step 2: Work through different parts of the input to set the output variables.
+
+    // If statement that handles differences between register definitions (which have operations)
+    // and register references (which do not).
+    if let Some(operations) = &register.operations {
+        element_bound =
+            quote![#tock_registers::Register<DataType = #element_type> #(+ #operations)*];
+        bus_bound =
+            quote_spanned![element_type.span()=>#tock_registers::DataTypeBus<#element_type>];
+        let struct_name = match is_scalar {
+            true => "Real",
+            false => "Element",
+        };
+        element_definition = register_definition(
+            tock_registers,
+            struct_doc_comment(is_scalar),
+            &layout.bus.generic_default(),
+            &Ident::new(struct_name, Span::call_site()),
+            register,
+            operations,
+        );
+        real = quote![Element<B>];
+    } else {
+        element_bound = quote![#element_type::Interface];
+        bus_bound = quote_spanned![element_type.span()=>#element_type::Bus];
+        element_definition = quote![];
+        real = quote![#element_type::Real<B>];
+    }
+    let mut interface_bound = element_bound.clone();
+    // match that handles the difference between scalar registers, non-nested array registers, and
+    // nested array registers.
+    let (mut len_definition, len_types_sizes) = match register.array_sizes.as_slice() {
+        [] => (TokenStream::new(), vec![]),
+        #[rustfmt::skip]
+        [len] => (quote![pub enum Len {}], vec![(quote![Len], len)]),
+        #[rustfmt::skip]
+        nested => (
+            quote![pub enum Len<const N: usize> {}],
+            nested
+                .iter()
+                .enumerate()
+                .map(|(n, s)| (quote![Len<#n>], s))
+                .collect(),
+        ),
+    };
+    // Loop that runs once for each level of array nesting.
+    for (len_type, size) in len_types_sizes {
+        interface_bound =
+            quote![#tock_registers::RegisterArray<#len_type, Element: #interface_bound>];
+        len_definition.extend(quote! {
+            impl #tock_registers::array::Len for #len_type { const LEN: usize = #size; }
+        });
+        real = quote![#tock_registers::RealRegisterArray<#real, #len_type>];
+    }
+    // If statement that switches on whether this is a scalar register definition or not.
+    let real_alias = if is_scalar && is_definition {
+        quote![]
+    } else {
+        let real_alias_comment = real_alias_doc_comment();
+        quote![#real_alias_comment pub type Real<B> = #real;]
+    };
+    // Match statement that switches on whether this is a scalar register, array definition, or
+    // array reference.
+    let impl_bound_type = match (is_scalar, is_definition) {
+        (true, _) => quote![Self],
+        (false, true) => quote![Element<B>],
+        (false, false) => quote![#element_type::Real<B>],
+    };
+
+    // Step 3: the final quote! call that puts everything together.
+    quote! {
+        #(#docs)*
+        #visibility mod #name {
+            #allows use super::*;
+            #interface_comment pub trait Interface: #interface_bound {}
+            #len_definition
+            #bus_comment pub trait Bus: #bus_bound + sealed::Bus {}
+            #(impl Bus for #buses {})*
+            #(impl sealed::Bus for #buses {})*
+            impl<B: Bus> Bus for #tock_registers::BorrowedBus<'_, B> {}
+            impl<B: Bus> sealed::Bus for #tock_registers::BorrowedBus<'_, B> {}
+            mod sealed { pub trait Bus {} }
+            #element_definition
+            #real_alias
+            impl<B: Bus> Interface for Real<B> where #impl_bound_type: #element_bound {}
+        }
+    }
+}
+
+pub fn interface_doc_comment() -> TokenStream {
+    quote! {
+        /// Trait representing this register's operations. Driver code can use this trait to work
+        /// with both real hardware and fake implementations of the register (for unit testing).
+    }
+}
+
+pub fn bus_doc_comment() -> TokenStream {
+    quote! {
+        /// Buses supported by this register.
+    }
+}
+
+pub fn struct_doc_comment(is_scalar: bool) -> TokenStream {
+    match is_scalar {
+        true => quote! {
+            /// Struct that implements [Interface] for use with the real hardware.
+        },
+        false => quote! {
+            /// Implementation of an element of this register array for use with real hardware.
+            /// This implements the tock_registers::Register trait as well as any operation traits
+            /// specified in the register definition.
+        },
+    }
+}
+
+pub fn real_alias_doc_comment() -> TokenStream {
+    quote! {
+        /// Implementation of [Interface] for use with real hardware.
+    }
+}

--- a/codegen/src/single_test_array.rs
+++ b/codegen/src/single_test_array.rs
@@ -1,0 +1,215 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+// Copyright Better Bytes 2026.
+
+use crate::single::{
+    bus_doc_comment, interface_doc_comment, real_alias_doc_comment, struct_doc_comment,
+};
+use crate::{new_doc_comment, register_map, test_util::assert_tokens_eq, Env::ProcMacro};
+use quote::quote;
+
+/// This serves two purposes: it tests the code generation of single flat (non-nested) array
+/// register definitions, and also documents (via comments) some of the trickier parts of the
+/// generated code.
+#[test]
+fn flat_array_definition_example() {
+    let input = quote! {
+        ::tock_registers
+        #[buses(Mmio32, Mmio64)]
+        pub foo: [u8; 2] { Read, Write }
+    };
+    let interface_comment = interface_doc_comment();
+    let bus_comment = bus_doc_comment();
+    let struct_comment = struct_doc_comment(false);
+    let new_comment = new_doc_comment();
+    let real_alias_comment = real_alias_doc_comment();
+    let expected = quote! {
+        pub mod foo {
+            use super::*;
+            // For arrays, we wrap the element's operations in a RegisterArray<> trait.
+            #interface_comment pub trait Interface: ::tock_registers::RegisterArray<Len,
+                Element: ::tock_registers::Register<DataType = u8> + Read + Write> {}
+            // For flat arrays, Len does not need to be generic.
+            pub enum Len {}
+            impl ::tock_registers::array::Len for Len { const LEN: usize = 2; }
+            #bus_comment pub trait Bus: ::tock_registers::DataTypeBus<u8> + sealed::Bus {}
+            impl Bus for Mmio32 {}
+            impl Bus for Mmio64 {}
+            impl sealed::Bus for Mmio32 {}
+            impl sealed::Bus for Mmio64 {}
+            impl<B: Bus> Bus for ::tock_registers::BorrowedBus<'_, B> {}
+            impl<B: Bus> sealed::Bus for ::tock_registers::BorrowedBus<'_, B> {}
+            mod sealed { pub trait Bus {} }
+            #struct_comment #[derive(Clone)] pub struct Element<B: Bus> {
+                address: B,
+                _phantom: ::tock_registers::internal::RealPhantom,
+            }
+            impl<B: Bus> Element<B> {
+                #new_comment pub const unsafe fn new(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+            }
+            impl<B: Bus> ::tock_registers::internal::core::marker::Copy for Element<B> {}
+            unsafe impl<B: Bus> ::tock_registers::Span for Element<B> {
+                type Address = B;
+                const SIZE: usize = <B as ::tock_registers::DataTypeBus<u8>>::PADDED_SIZE;
+                unsafe fn with_addr(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+                type Borrowed<'b> = Element<::tock_registers::BorrowedBus<'b, B>>;
+            }
+            impl<B: Bus> ::tock_registers::Register for Element<B> { type DataType = u8; }
+            Read!(real_impl, Element, u8,,);
+            Write!(real_impl, Element, u8,,);
+            #real_alias_comment
+            pub type Real<B> = ::tock_registers::RealRegisterArray<Element<B>, Len>;
+            impl<B: Bus> Interface for Real<B> where
+                // Rust DOES understand that RealRegisterArray<> implements RegisterArray<>, so we
+                // don't need to fully copy Interface's bounds list here. However, we do need to
+                // copy the bounds on the innermost element type, for the same reasons as for
+                // scalar registers.
+                Element<B>: ::tock_registers::Register<DataType = u8> + Read + Write {}
+        }
+    };
+    assert_tokens_eq(register_map(input, ProcMacro).unwrap(), expected);
+}
+
+/// This serves two purposes: it tests the code generation of single nested array register
+/// definitions, and also documents (via comments) some of the trickier parts of the generated
+/// code.
+#[test]
+fn nested_array_definition_example() {
+    let input = quote! {
+        ::tock_registers
+        #[buses(Mmio32, Mmio64)]
+        pub foo: [[u8; 2]; 3] { Read, Write }
+    };
+    let interface_comment = interface_doc_comment();
+    let bus_comment = bus_doc_comment();
+    let struct_comment = struct_doc_comment(false);
+    let new_comment = new_doc_comment();
+    let real_alias_comment = real_alias_doc_comment();
+    let expected = quote! {
+        pub mod foo {
+            use super::*;
+            // When arrays are nested, the RegisterArray traits are nested as well.
+            #interface_comment pub trait Interface: ::tock_registers::RegisterArray<Len<1usize>,
+                Element: ::tock_registers::RegisterArray<Len<0usize>,
+                    Element: ::tock_registers::Register<DataType = u8> + Read + Write
+                >
+            > {}
+            // For nested arrays, Len is generic. Len<0> is the innermost array's length, and the
+            // highest-N Len is the outermost array's length.
+            pub enum Len<const N: usize> {}
+            impl ::tock_registers::array::Len for Len<0usize> { const LEN: usize = 2; }
+            impl ::tock_registers::array::Len for Len<1usize> { const LEN: usize = 3; }
+            #bus_comment pub trait Bus: ::tock_registers::DataTypeBus<u8> + sealed::Bus {}
+            impl Bus for Mmio32 {}
+            impl Bus for Mmio64 {}
+            impl sealed::Bus for Mmio32 {}
+            impl sealed::Bus for Mmio64 {}
+            impl<B: Bus> Bus for ::tock_registers::BorrowedBus<'_, B> {}
+            impl<B: Bus> sealed::Bus for ::tock_registers::BorrowedBus<'_, B> {}
+            mod sealed { pub trait Bus {} }
+            #struct_comment #[derive(Clone)] pub struct Element<B: Bus> {
+                address: B,
+                _phantom: ::tock_registers::internal::RealPhantom,
+            }
+            impl<B: Bus> Element<B> {
+                #new_comment pub const unsafe fn new(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+            }
+            impl<B: Bus> ::tock_registers::internal::core::marker::Copy for Element<B> {}
+            unsafe impl<B: Bus> ::tock_registers::Span for Element<B> {
+                type Address = B;
+                const SIZE: usize = <B as ::tock_registers::DataTypeBus<u8>>::PADDED_SIZE;
+                unsafe fn with_addr(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+                type Borrowed<'b> = Element<::tock_registers::BorrowedBus<'b, B>>;
+            }
+            impl<B: Bus> ::tock_registers::Register for Element<B> { type DataType = u8; }
+            Read!(real_impl, Element, u8,,);
+            Write!(real_impl, Element, u8,,);
+            #real_alias_comment pub type Real<B> = ::tock_registers::RealRegisterArray<
+                ::tock_registers::RealRegisterArray<Element<B>, Len<0usize> >, Len<1usize> >;
+            impl<B: Bus> Interface for Real<B> where
+                Element<B>: ::tock_registers::Register<DataType = u8> + Read + Write {}
+        }
+    };
+    assert_tokens_eq(register_map(input, ProcMacro).unwrap(), expected);
+}
+
+/// This serves two purposes: it tests the code generation of single flat array register
+/// references, and also documents (via comments) some of the trickier parts of the generated code.
+#[test]
+fn flat_array_reference_example() {
+    let input = quote! {
+        ::tock_registers
+        #[buses(Mmio32, Mmio64)]
+        pub foo: [status; 2],
+    };
+    let interface_comment = interface_doc_comment();
+    let bus_comment = bus_doc_comment();
+    let real_alias_comment = real_alias_doc_comment();
+    let expected = quote! {
+        pub mod foo {
+            use super::*;
+            #interface_comment pub trait Interface:
+                ::tock_registers::RegisterArray<Len, Element: status::Interface> {}
+            pub enum Len {}
+            impl ::tock_registers::array::Len for Len { const LEN: usize = 2; }
+            #bus_comment pub trait Bus: status::Bus + sealed::Bus {}
+            impl Bus for Mmio32 {}
+            impl Bus for Mmio64 {}
+            impl sealed::Bus for Mmio32 {}
+            impl sealed::Bus for Mmio64 {}
+            impl<B: Bus> Bus for ::tock_registers::BorrowedBus<'_, B> {}
+            impl<B: Bus> sealed::Bus for ::tock_registers::BorrowedBus<'_, B> {}
+            mod sealed { pub trait Bus {} }
+            #real_alias_comment
+            pub type Real<B> = ::tock_registers::RealRegisterArray<status::Real<B>, Len>;
+            impl<B: Bus> Interface for Real<B> where status::Real<B>: status::Interface {}
+        }
+    };
+    assert_tokens_eq(register_map(input, ProcMacro).unwrap(), expected);
+}
+
+/// This serves two purposes: it tests the code generation of single nested array register
+/// references, and also documents (via comments) some of the trickier parts of the generated code.
+#[test]
+fn nested_array_reference_example() {
+    let input = quote! {
+        ::tock_registers
+        #[buses(Mmio32, Mmio64)]
+        pub foo: [[status; 2]; 3],
+    };
+    let interface_comment = interface_doc_comment();
+    let bus_comment = bus_doc_comment();
+    let real_alias_comment = real_alias_doc_comment();
+    let expected = quote! {
+        pub mod foo {
+            use super::*;
+            #interface_comment pub trait Interface: ::tock_registers::RegisterArray<Len<1usize>,
+                Element: ::tock_registers::RegisterArray<Len<0usize>, Element: status::Interface>
+            > {}
+            pub enum Len<const N: usize> {}
+            impl ::tock_registers::array::Len for Len<0usize> { const LEN: usize = 2; }
+            impl ::tock_registers::array::Len for Len<1usize> { const LEN: usize = 3; }
+            #bus_comment pub trait Bus: status::Bus + sealed::Bus {}
+            impl Bus for Mmio32 {}
+            impl Bus for Mmio64 {}
+            impl sealed::Bus for Mmio32 {}
+            impl sealed::Bus for Mmio64 {}
+            impl<B: Bus> Bus for ::tock_registers::BorrowedBus<'_, B> {}
+            impl<B: Bus> sealed::Bus for ::tock_registers::BorrowedBus<'_, B> {}
+            mod sealed { pub trait Bus {} }
+            #real_alias_comment pub type Real<B> = ::tock_registers::RealRegisterArray<
+                ::tock_registers::RealRegisterArray<status::Real<B>, Len<0usize> >, Len<1usize> >;
+            impl<B: Bus> Interface for Real<B> where status::Real<B>: status::Interface {}
+        }
+    };
+    assert_tokens_eq(register_map(input, ProcMacro).unwrap(), expected);
+}

--- a/codegen/src/single_test_docs.rs
+++ b/codegen/src/single_test_docs.rs
@@ -1,0 +1,257 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+// Copyright Better Bytes 2026.
+
+//! These test cases verify that:
+//!
+//! 1. Doc comments that should be copied from the input are copied correctly.
+//! 2. Generated doc comments are correct.
+
+use crate::{register_map, test_util::assert_tokens_eq, Env::ProcMacro};
+use quote::quote;
+
+#[test]
+fn scalar_definition() {
+    let input = quote! {
+        ::tock_registers
+        //! Doc comment A
+        //! Doc comment B
+        #![buses(Mmio32, Mmio64)]
+        //! Doc comment C
+        //! Doc comment D
+        /// Doc comment E
+        /// Doc comment F
+        pub foo: u8 { Read, Write },
+    };
+    let expected = quote! {
+        /// Doc comment A
+        /// Doc comment B
+        /// Doc comment C
+        /// Doc comment D
+        /// Doc comment E
+        /// Doc comment F
+        pub mod foo {
+            use super::*;
+            /// Trait representing this register's operations. Driver code can use this trait to work
+            /// with both real hardware and fake implementations of the register (for unit testing).
+            pub trait Interface: ::tock_registers::Register<DataType = u8> + Read + Write {}
+            /// Buses supported by this register.
+            pub trait Bus: ::tock_registers::DataTypeBus<u8> + sealed::Bus {}
+            impl Bus for Mmio32 {}
+            impl Bus for Mmio64 {}
+            impl sealed::Bus for Mmio32 {}
+            impl sealed::Bus for Mmio64 {}
+            impl<B: Bus> Bus for ::tock_registers::BorrowedBus<'_, B> {}
+            impl<B: Bus> sealed::Bus for ::tock_registers::BorrowedBus<'_, B> {}
+            mod sealed { pub trait Bus {} }
+            /// Struct that implements [Interface] for use with the real hardware.
+            #[derive(Clone)] pub struct Real<B: Bus> {
+                address: B,
+                _phantom: ::tock_registers::internal::RealPhantom,
+            }
+            impl<B: Bus> Real<B> {
+                /// Constructs an accessor for this register or register block.
+                /// # Safety
+                /// 1. `address` must point to register(s) on the bus corresponding to
+                ///    `B`.
+                /// 2. The register(s)' definition (as provided to the
+                ///    `tock_registers::register_map!` macro) must correctly
+                ///    describe the pointed-to register(s).
+                /// 3. The returned register accessor must not be used in a way that
+                ///    causes data races. The exact requirements depend on the hardware,
+                ///    but it's usually best to access a register from only one thread
+                ///    at a time.
+                pub const unsafe fn new(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+            }
+            impl<B: Bus> ::tock_registers::internal::core::marker::Copy for Real<B> {}
+            unsafe impl<B: Bus> ::tock_registers::Span for Real<B> {
+                type Address = B;
+                const SIZE: usize = <B as ::tock_registers::DataTypeBus<u8>>::PADDED_SIZE;
+                unsafe fn with_addr(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+                type Borrowed<'b> = Real<::tock_registers::BorrowedBus<'b, B>>;
+            }
+            impl<B: Bus> ::tock_registers::Register for Real<B> { type DataType = u8; }
+            Read!(real_impl, Real, u8,,);
+            Write!(real_impl, Real, u8,,);
+            impl<B: Bus> Interface for Real<B> where
+                Self: ::tock_registers::Register<DataType = u8> + Read + Write {}
+        }
+    };
+    assert_tokens_eq(register_map(input, ProcMacro).unwrap(), expected);
+}
+
+#[test]
+fn array_definition() {
+    let input = quote! {
+        ::tock_registers
+        //! Doc comment A
+        //! Doc comment B
+        #![buses(Mmio32, Mmio64)]
+        //! Doc comment C
+        //! Doc comment D
+        /// Doc comment E
+        /// Doc comment F
+        pub foo: [u8; 2] { Read, Write }
+    };
+    let expected = quote! {
+        /// Doc comment A
+        /// Doc comment B
+        /// Doc comment C
+        /// Doc comment D
+        /// Doc comment E
+        /// Doc comment F
+        pub mod foo {
+            use super::*;
+            /// Trait representing this register's operations. Driver code can use this trait to work
+            /// with both real hardware and fake implementations of the register (for unit testing).
+            pub trait Interface: ::tock_registers::RegisterArray<Len,
+                Element: ::tock_registers::Register<DataType = u8> + Read + Write> {}
+            pub enum Len {}
+            impl ::tock_registers::array::Len for Len { const LEN: usize = 2; }
+            /// Buses supported by this register.
+            pub trait Bus: ::tock_registers::DataTypeBus<u8> + sealed::Bus {}
+            impl Bus for Mmio32 {}
+            impl Bus for Mmio64 {}
+            impl sealed::Bus for Mmio32 {}
+            impl sealed::Bus for Mmio64 {}
+            impl<B: Bus> Bus for ::tock_registers::BorrowedBus<'_, B> {}
+            impl<B: Bus> sealed::Bus for ::tock_registers::BorrowedBus<'_, B> {}
+            mod sealed { pub trait Bus {} }
+            /// Implementation of an element of this register array for use with real hardware.
+            /// This implements the tock_registers::Register trait as well as any operation traits
+            /// specified in the register definition.
+            #[derive(Clone)] pub struct Element<B: Bus> {
+                address: B,
+                _phantom: ::tock_registers::internal::RealPhantom,
+            }
+            impl<B: Bus> Element<B> {
+                /// Constructs an accessor for this register or register block.
+                /// # Safety
+                /// 1. `address` must point to register(s) on the bus corresponding to
+                ///    `B`.
+                /// 2. The register(s)' definition (as provided to the
+                ///    `tock_registers::register_map!` macro) must correctly
+                ///    describe the pointed-to register(s).
+                /// 3. The returned register accessor must not be used in a way that
+                ///    causes data races. The exact requirements depend on the hardware,
+                ///    but it's usually best to access a register from only one thread
+                ///    at a time.
+                pub const unsafe fn new(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+            }
+            impl<B: Bus> ::tock_registers::internal::core::marker::Copy for Element<B> {}
+            unsafe impl<B: Bus> ::tock_registers::Span for Element<B> {
+                type Address = B;
+                const SIZE: usize = <B as ::tock_registers::DataTypeBus<u8>>::PADDED_SIZE;
+                unsafe fn with_addr(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+                type Borrowed<'b> = Element<::tock_registers::BorrowedBus<'b, B>>;
+            }
+            impl<B: Bus> ::tock_registers::Register for Element<B> { type DataType = u8; }
+            Read!(real_impl, Element, u8,,);
+            Write!(real_impl, Element, u8,,);
+            /// Implementation of [Interface] for use with real hardware.
+            pub type Real<B> = ::tock_registers::RealRegisterArray<Element<B>, Len>;
+            impl<B: Bus> Interface for Real<B> where
+                Element<B>: ::tock_registers::Register<DataType = u8> + Read + Write {}
+        }
+    };
+    assert_tokens_eq(register_map(input, ProcMacro).unwrap(), expected);
+}
+
+#[test]
+fn scalar_reference() {
+    let input = quote! {
+        ::tock_registers
+        //! Doc comment A
+        //! Doc comment B
+        #![buses(Mmio32, Mmio64)]
+        //! Doc comment C
+        //! Doc comment D
+        /// Doc comment E
+        /// Doc comment F
+        pub foo: status,
+    };
+    let expected = quote! {
+        /// Doc comment A
+        /// Doc comment B
+        /// Doc comment C
+        /// Doc comment D
+        /// Doc comment E
+        /// Doc comment F
+        pub mod foo {
+            use super::*;
+            /// Trait representing this register's operations. Driver code can use this trait to work
+            /// with both real hardware and fake implementations of the register (for unit testing).
+            pub trait Interface: status::Interface {}
+            /// Buses supported by this register.
+            pub trait Bus: status::Bus + sealed::Bus {}
+            impl Bus for Mmio32 {}
+            impl Bus for Mmio64 {}
+            impl sealed::Bus for Mmio32 {}
+            impl sealed::Bus for Mmio64 {}
+            impl<B: Bus> Bus for ::tock_registers::BorrowedBus<'_, B> {}
+            impl<B: Bus> sealed::Bus for ::tock_registers::BorrowedBus<'_, B> {}
+            mod sealed { pub trait Bus {} }
+            /// Implementation of [Interface] for use with real hardware.
+            pub type Real<B> = status::Real<B>;
+            impl<B: Bus> Interface for Real<B> where Self: status::Interface {}
+        }
+    };
+    assert_tokens_eq(register_map(input, ProcMacro).unwrap(), expected);
+}
+
+#[test]
+fn array_reference() {
+    let input = quote! {
+        ::tock_registers
+        //! Doc comment A
+        //! Doc comment B
+        #![buses(Mmio32, Mmio64)]
+        //! Doc comment C
+        //! Doc comment D
+        /// Doc comment E
+        /// Doc comment F
+        pub foo: [[status; 2]; 3],
+    };
+    let expected = quote! {
+        /// Doc comment A
+        /// Doc comment B
+        /// Doc comment C
+        /// Doc comment D
+        /// Doc comment E
+        /// Doc comment F
+        pub mod foo {
+            use super::*;
+            /// Trait representing this register's operations. Driver code can use this trait to work
+            /// with both real hardware and fake implementations of the register (for unit testing).
+            pub trait Interface: ::tock_registers::RegisterArray<Len<1usize>,
+                Element: ::tock_registers::RegisterArray<Len<0usize>, Element: status::Interface>
+            > {}
+            pub enum Len<const N: usize> {}
+            impl ::tock_registers::array::Len for Len<0usize> { const LEN: usize = 2; }
+            impl ::tock_registers::array::Len for Len<1usize> { const LEN: usize = 3; }
+            /// Buses supported by this register.
+            pub trait Bus: status::Bus + sealed::Bus {}
+            impl Bus for Mmio32 {}
+            impl Bus for Mmio64 {}
+            impl sealed::Bus for Mmio32 {}
+            impl sealed::Bus for Mmio64 {}
+            impl<B: Bus> Bus for ::tock_registers::BorrowedBus<'_, B> {}
+            impl<B: Bus> sealed::Bus for ::tock_registers::BorrowedBus<'_, B> {}
+            mod sealed { pub trait Bus {} }
+            /// Implementation of [Interface] for use with real hardware.
+            pub type Real<B> = ::tock_registers::RealRegisterArray<
+                ::tock_registers::RealRegisterArray<status::Real<B>, Len<0usize> >, Len<1usize> >;
+            impl<B: Bus> Interface for Real<B> where status::Real<B>: status::Interface {}
+        }
+    };
+    assert_tokens_eq(register_map(input, ProcMacro).unwrap(), expected);
+}

--- a/codegen/src/single_test_scalar.rs
+++ b/codegen/src/single_test_scalar.rs
@@ -1,0 +1,171 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+// Copyright Better Bytes 2026.
+
+use crate::single::{
+    bus_doc_comment, interface_doc_comment, real_alias_doc_comment, struct_doc_comment,
+};
+use crate::{new_doc_comment, register_map, test_util::assert_tokens_eq, Env::External};
+use quote::quote;
+
+/// This serves two purposes: it tests the code generation of single scalar register definitions,
+/// and also documents (via comments) some of the trickier parts of the generated code.
+#[test]
+fn scalar_definition_example() {
+    let input = quote! {
+        ::tock_registers
+        #[buses(Mmio32, Mmio64)]
+        pub foo: u8 { Read, Write },
+    };
+    let interface_comment = interface_doc_comment();
+    let bus_comment = bus_doc_comment();
+    let struct_comment = struct_doc_comment(true);
+    let new_comment = new_doc_comment();
+    let expected = quote! {
+        pub mod foo {
+            #![allow(dead_code)] use super::*;
+            #interface_comment
+            pub trait Interface: ::tock_registers::Register<DataType = u8> + Read + Write {}
+            #bus_comment pub trait Bus:
+                // Bus needs this bound so that the Span impl for Real<B> can access PADDED_SIZE.
+                // It would be ideal to be able to bound BusRead/BusWrite as well, as that would
+                // allow us to remove the `where` clause from the `Interface for Real<B>` impl.
+                // However, we have to get those trait names from the operations' macros, and you
+                // cannot invoke macros from bounds list, so it is difficult to implement that
+                // bound. So we only generate the Bus<> bound, as it is the only necessary bound.
+                ::tock_registers::DataTypeBus<u8>
+                + sealed::Bus {}
+            impl Bus for Mmio32 {}
+            impl Bus for Mmio64 {}
+            impl sealed::Bus for Mmio32 {}
+            impl sealed::Bus for Mmio64 {}
+            impl<B: Bus> Bus for ::tock_registers::BorrowedBus<'_, B> {}
+            impl<B: Bus> sealed::Bus for ::tock_registers::BorrowedBus<'_, B> {}
+            mod sealed { pub trait Bus {} }
+            #struct_comment #[derive(Clone)] pub struct Real<B: Bus> {
+                address: B,
+                _phantom: ::tock_registers::internal::RealPhantom,
+            }
+            impl<B: Bus> Real<B> {
+                #new_comment pub const unsafe fn new(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+            }
+            // We could just use `#[derive(Copy)]` on `Real`, but that generates more-complex code
+            // than necessary (it has unnecessary trait bounds). Instead, this macro emits the Copy
+            // impl directly.
+            impl<B: Bus> ::tock_registers::internal::core::marker::Copy for Real<B> {}
+            unsafe impl<B: Bus> ::tock_registers::Span for Real<B> {
+                type Address = B;
+                const SIZE: usize = <B as ::tock_registers::DataTypeBus<u8>>::PADDED_SIZE;
+                unsafe fn with_addr(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+                type Borrowed<'b> = Real<::tock_registers::BorrowedBus<'b, B>>;
+            }
+            impl<B: Bus> ::tock_registers::Register for Real<B> { type DataType = u8; }
+            Read!(real_impl, Real, u8,,);
+            Write!(real_impl, Real, u8,,);
+            impl<B: Bus> Interface for Real<B> where
+                // Rust understands that Real<B> always implements Register, but it does not
+                // understand that Register::DataType is always u8. Therefore we have to add this
+                // bound, to match the bounds on the `Interface` trait definition.
+                Self: ::tock_registers::Register<DataType = u8>
+                // We have the same issue as Bus here -- Rust doesn't know that every Bus impl is
+                // BusRead/BusWrite so it doesn't know that every Real<> is Read/Write. Therefore
+                // we have to bound Read + Write here to match Interface's definition.
+                + Read + Write {}
+        }
+    };
+    assert_tokens_eq(register_map(input, External).unwrap(), expected);
+}
+
+/// This serves two purposes: it tests the code generation of single scalar register references,
+/// and also documents (via comments) some of the trickier parts of the generated code.
+#[test]
+fn scalar_reference_example() {
+    let input = quote! {
+        ::tock_registers
+        #[buses(Mmio32, Mmio64)]
+        pub foo: status,
+    };
+    let interface_comment = interface_doc_comment();
+    let bus_comment = bus_doc_comment();
+    let real_alias_comment = real_alias_doc_comment();
+    let expected = quote! {
+        pub mod foo {
+            #![allow(dead_code)] use super::*;
+            #interface_comment pub trait Interface: status::Interface {}
+            #bus_comment pub trait Bus: status::Bus + sealed::Bus {}
+            impl Bus for Mmio32 {}
+            impl Bus for Mmio64 {}
+            impl sealed::Bus for Mmio32 {}
+            impl sealed::Bus for Mmio64 {}
+            impl<B: Bus> Bus for ::tock_registers::BorrowedBus<'_, B> {}
+            impl<B: Bus> sealed::Bus for ::tock_registers::BorrowedBus<'_, B> {}
+            mod sealed { pub trait Bus {} }
+            #real_alias_comment pub type Real<B> = status::Real<B>;
+            impl<B: Bus> Interface for Real<B> where
+                // Similar to definitions, without this bound Rust does not understand that every
+                // Bus implements BusRead/BusWrite as needed.
+                Self: status::Interface {}
+        }
+    };
+    assert_tokens_eq(register_map(input, External).unwrap(), expected);
+}
+
+/// Verifies that generic arguments on operations are correctly copied to the output (they need to
+/// be split off the operation path for the operation macro invocation).
+///
+/// This also doubles as the test for `#[bus]`.
+#[test]
+fn generic_operation() {
+    let input = quote! {
+        ::tock_registers
+        #[bus(Mmio32)]
+        foo: u8 { Dance<Waltz> },
+    };
+    let interface_comment = interface_doc_comment();
+    let bus_comment = bus_doc_comment();
+    let struct_comment = struct_doc_comment(true);
+    let new_comment = new_doc_comment();
+    let expected = quote! {
+        mod foo {
+            #![allow(dead_code)] use super::*;
+            #interface_comment
+            pub trait Interface: ::tock_registers::Register<DataType = u8> + Dance<Waltz> {}
+            #bus_comment pub trait Bus: ::tock_registers::DataTypeBus<u8> + sealed::Bus {}
+            impl Bus for Mmio32 {}
+            impl sealed::Bus for Mmio32 {}
+            impl<B: Bus> Bus for ::tock_registers::BorrowedBus<'_, B> {}
+            impl<B: Bus> sealed::Bus for ::tock_registers::BorrowedBus<'_, B> {}
+            mod sealed { pub trait Bus {} }
+            #struct_comment #[derive(Clone)] pub struct Real<B: Bus = Mmio32> {
+                address: B,
+                _phantom: ::tock_registers::internal::RealPhantom,
+            }
+            impl<B: Bus> Real<B> {
+                #new_comment pub const unsafe fn new(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+            }
+            impl<B: Bus> ::tock_registers::internal::core::marker::Copy for Real<B> {}
+            unsafe impl<B: Bus> ::tock_registers::Span for Real<B> {
+                type Address = B;
+                const SIZE: usize = <B as ::tock_registers::DataTypeBus<u8>>::PADDED_SIZE;
+                unsafe fn with_addr(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+                type Borrowed<'b> = Real<::tock_registers::BorrowedBus<'b, B>>;
+            }
+            impl<B: Bus> ::tock_registers::Register for Real<B> { type DataType = u8; }
+            // Since macros cannot accept generic arguments, the generics are instead detached
+            // from the operation path and moved into an argument of the macro invocation.
+            Dance!(real_impl, Real, u8, <Waltz>,);
+            impl<B: Bus> Interface for Real<B> where
+                Self: ::tock_registers::Register<DataType = u8> + Dance<Waltz> {}
+        }
+    };
+    assert_tokens_eq(register_map(input, External).unwrap(), expected);
+}

--- a/codegen/src/test_util.rs
+++ b/codegen/src/test_util.rs
@@ -10,7 +10,6 @@ use syn::parse2;
 
 /// Asserts that two token streams are identical. If they differ, panics with a
 /// pretty-printed diff.
-#[allow(unused)] // TODO: Remove when code generation has been merged.
 #[track_caller]
 pub fn assert_tokens_eq(left: TokenStream, right: TokenStream) {
     if let Err((left, right)) = assert_tokens_eq_impl(left, right) {


### PR DESCRIPTION
This generates code for all layout types except for register blocks, which are in a separate PR.

I added a `#[rustfmt::skip]` to avoid a merge error between this PR and the block generation PR. I didn't realize it in my parse PR, but `rustfmt`'s choice to line up my `// TODO` comments will cause a merge conflict. I'll clean this up as soon as I can do so without causing that conflict.