### PR TITLE
Add register block code generation.

### DIFF
--- a/codegen/src/ast.rs
+++ b/codegen/src/ast.rs
@@ -5,8 +5,6 @@
 
 //! The Abstract Syntax Tree for a register_map! invocation.
 
-#![allow(unused)] // TODO: Remove once code generation (block, single) is merged.
-
 // TODO: Remove `ignore` from the doc tests once the macros and Read/Write ops have been merged.
 
 use proc_macro2::TokenStream;

--- a/codegen/src/block.rs
+++ b/codegen/src/block.rs
@@ -1,0 +1,293 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+// Copyright Better Bytes 2026.
+
+use crate::ast::{Field, FieldDef, Layout, PerBusInt};
+use crate::{new_doc_comment, register_definition, Env};
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote, quote_spanned};
+use syn::{spanned::Spanned, Ident, Path, TypePath};
+
+/// Generates the module for a register block.
+pub fn generate(env: Env, tock_registers: &Path, layout: &Layout, fields: &[Field]) -> TokenStream {
+    // At a high level, this function has:
+    //
+    // 1. A set of variable declarations (of type TokenStream or Vec<TokenStream>)
+    // 2. A loop that loops through each field, adding to the variable declarations.
+    // 3. A final quote! invocation that combines the variable declarations into the output code.
+    //
+    // This pattern avoids the need to have separate loops for each portion of the generated code,
+    // which removes a lot of code duplication.
+    //
+    // This is generally more complex than single::generate, so if you need to understand/modify
+    // both functions, consider working on single::generate first. That knowledge will transfer
+    // over to this function.
+    //
+    // The advice from single::generate's comment about looking at the generated code first, then
+    // tracing backwards through the final quote! invocation to find the relevant variables works
+    // in this function as well. block_test_all_fields is a good test to look at first.
+
+    // Step 1: variable declarations
+    let env_allows = match env {
+        Env::External => quote![,dead_code,non_upper_case_globals],
+        Env::ProcMacro => quote![],
+    };
+    let docs = &layout.docs;
+    let visibility = &layout.visibility;
+    let name = &layout.name;
+    let interface_comment = interface_doc_comment();
+    let mut interface_fields = TokenStream::new();
+    let mut len_definitions = TokenStream::new();
+    let bus_comment = bus_doc_comment();
+    let mut bus_bounds = TokenStream::new();
+    let mut bus_offset_decls = TokenStream::new();
+    let buses = layout.bus.as_slice();
+    // cumulative_sizes is empty if the current cumulative size is unknown (due to a padding field
+    // with no specified size).
+    let mut cumulative_sizes: Vec<_> = (0..buses.len()).map(|_| quote![0]).collect();
+    let mut bus_offset_defs: Vec<_> = (0..buses.len()).map(|_| TokenStream::new()).collect();
+    let mut borrowed_bus_defs = TokenStream::new();
+    let mut offset_tests = TokenStream::new();
+    let bus_default = layout.bus.generic_default();
+    let real_comment = real_doc_comment();
+    let new_comment = new_doc_comment();
+    let mut interface_bounds = TokenStream::new();
+    let mut interface_impl_items = TokenStream::new();
+    let mut real_structs = TokenStream::new();
+
+    // Step 2: Loop through each field, update the variables.
+    for field in fields.iter() {
+        // This `match` statement handles padding and `continue`s to the next iteration on padding
+        // fields, so the rest of the body of this loop does not need to special-case for padding.
+        let (docs, aliased, name, register) = match &field.field_def {
+            FieldDef::Padding(sizes) => {
+                add_offset_tests(
+                    tock_registers,
+                    &mut offset_tests,
+                    buses,
+                    &cumulative_sizes,
+                    &field.offsets,
+                );
+                cumulative_sizes.clear();
+                if let Some(sizes) = sizes {
+                    for bus_idx in 0..buses.len() {
+                        let offset = &field.offsets[bus_idx];
+                        let size = &sizes[bus_idx];
+                        cumulative_sizes.push(quote![#offset + #size]);
+                    }
+                }
+                continue;
+            }
+            FieldDef::Register {
+                docs,
+                aliased,
+                name,
+                spec,
+            } => (docs, *aliased, name, spec),
+        };
+        // The rest of this loop body is for register fields. It consists of a series of
+        // conditionals and loops that all switch/iterate on a different aspect of the field.
+        let element_type = &register.element_type;
+        let mut interface_bound;
+        let mut real;
+        // If statement that handles differences between register definitions (which have
+        // operations) and register references (which do not).
+        if let Some(operations) = &register.operations {
+            interface_bound =
+                quote![#tock_registers::Register<DataType = #element_type> #(+ #operations)*];
+            let real_name = format_ident!("real_{name}");
+            real = quote![#real_name<B>];
+            let bus_trait = quote![#tock_registers::DataTypeBus<#element_type>];
+            bus_bounds.extend(quote![+ #bus_trait]);
+            real_structs.extend(register_definition(
+                tock_registers,
+                field_struct_doc_comment(name),
+                &bus_default,
+                &real_name,
+                register,
+                operations,
+            ));
+        } else {
+            interface_bound = quote![#element_type::Interface];
+            real = quote![#element_type::Real<B>];
+            bus_bounds.extend(quote_spanned![element_type.span()=>+ #element_type::Bus]);
+        };
+        interface_bounds.extend(quote![#real: #interface_bound,]);
+        // match that handles the difference between scalar registers, non-nested array registers,
+        // and nested array registers.
+        let len_types_sizes = match register.array_sizes.as_slice() {
+            [] => vec![],
+            [len] => {
+                len_definitions.extend(quote![pub enum #name {}]);
+                vec![(quote![#name], len)]
+            }
+            nested => {
+                len_definitions.extend(quote![pub enum #name<const N: usize> {}]);
+                nested
+                    .iter()
+                    .enumerate()
+                    .map(|(n, s)| (quote![#name<#n>], s))
+                    .collect()
+            }
+        };
+        // Loop that runs once for each level of array nesting.
+        for (len_type, size) in len_types_sizes {
+            interface_bound =
+                quote![#tock_registers::RegisterArray<lens::#len_type, Element: #interface_bound>];
+            len_definitions.extend(quote! {
+                impl #tock_registers::array::Len for #len_type { const LEN: usize = #size; }
+            });
+            real = quote![#tock_registers::RealRegisterArray<#real, lens::#len_type>];
+        }
+        interface_fields.extend(quote! {
+            type #name: #interface_bound;
+            #(#docs)* fn #name(self) -> Self::#name;
+        });
+        let name_offset = format_ident!("{name}_offset");
+        // match that handles the difference between scalar offset definitions and array offset
+        // definitions (moves the value of the name_offset fields between the Bus trait definition
+        // and impls).
+        bus_offset_decls.extend(match &field.offsets {
+            PerBusInt::Array(offsets) => {
+                for (bus_idx, offset) in offsets.iter().enumerate() {
+                    bus_offset_defs[bus_idx].extend(quote![const #name_offset: usize = #offset;]);
+                }
+                borrowed_bus_defs
+                    .extend(quote![const #name_offset: usize = <B as Bus>::#name_offset;]);
+                quote![const #name_offset: usize;]
+            }
+            PerBusInt::Single(offset) => quote![const #name_offset: usize = #offset;],
+        });
+        // if that handles aliased vs. non-aliased fields.
+        if !aliased {
+            add_offset_tests(
+                tock_registers,
+                &mut offset_tests,
+                buses,
+                &cumulative_sizes,
+                &field.offsets,
+            );
+            cumulative_sizes.clear();
+            for (bus_idx, bus) in buses.iter().enumerate() {
+                let offset = &field.offsets[bus_idx];
+                cumulative_sizes.push(quote![#offset + <<Real<#bus> as Interface>::#name as #tock_registers::Span>::SIZE]);
+            }
+        }
+        interface_impl_items.extend(quote! {
+            type #name = #real;
+            fn #name(self) -> Self::#name {
+                // Safety (see crate::new_doc_comment() for requirements):
+                // 1. When Self::new was called to construct `self`, the caller guaranteed that the
+                //    passed address points to registers on the bus of type B.
+                // 2. The definition of this register block is correct (guaranteed by the caller of
+                //    Self::new), which guarantees that a register corresponding to the #real type
+                //    exists at B::name_offset. This also guarantees that the byte_add does not
+                //    leave the register block.
+                // 3. The user of this struct is responsible for using the entire register block in
+                //    a way that avoids data races, which includes the responsibility to avoid data
+                //    races on individual fields of the register block.
+                unsafe {
+                    Self::#name::new(self.address.byte_add(<B as Bus>::#name_offset))
+                }
+            }
+        });
+    }
+
+    // Step 3: the final quote! call that puts everything together.
+    quote! {
+        #(#docs)*
+        #visibility mod #name {
+            #![allow(non_camel_case_types #env_allows)] use super::*;
+            #interface_comment pub trait Interface: #tock_registers::internal::core::marker::Copy {
+                #interface_fields
+            }
+            pub mod lens { #len_definitions }
+            #bus_comment #[allow(clippy::trait_duplication_in_bounds)]
+            pub trait Bus: #tock_registers::Address #bus_bounds + sealed::Bus {
+                const SIZE: usize;
+                #bus_offset_decls
+            }
+            #(
+                impl Bus for #buses {
+                    const SIZE: usize = #cumulative_sizes;
+                    #bus_offset_defs
+                }
+                impl sealed::Bus for #buses {}
+            )*
+            impl<B: Bus> Bus for #tock_registers::BorrowedBus<'_, B> {
+                const SIZE: usize = <B as Bus>::SIZE;
+                #borrowed_bus_defs
+            }
+            impl<B: Bus> sealed::Bus for #tock_registers::BorrowedBus<'_, B> {}
+            const _: () = { #offset_tests };
+            mod sealed { pub trait Bus {} }
+            #real_comment #[derive(Clone)] pub struct Real<B: Bus #bus_default> {
+                address: B,
+                _phantom: #tock_registers::internal::RealPhantom,
+            }
+            impl<B: Bus> Real<B> {
+                #new_comment pub const unsafe fn new(address: B) -> Self {
+                    Self { address, _phantom: #tock_registers::internal::RealPhantom::new() }
+                }
+            }
+            impl<B: Bus> #tock_registers::internal::core::marker::Copy for Real<B> {}
+            impl<B: Bus> Interface for Real<B> where #interface_bounds {
+                #interface_impl_items
+            }
+            // Safety: Our size calculation for Bus::SIZE is correct. Bus is sealed, so there can
+            // be no other implementations of Bus.
+            unsafe impl<B: Bus> #tock_registers::Span for Real<B> {
+                type Address = B;
+                const SIZE: usize = <B as Bus>::SIZE;
+                unsafe fn with_addr(address: B) -> Self {
+                    Self { address, _phantom: #tock_registers::internal::RealPhantom::new() }
+                }
+                type Borrowed<'b> = Real<#tock_registers::BorrowedBus<'b, B>>;
+            }
+            #real_structs
+        }
+    }
+}
+
+pub fn interface_doc_comment() -> TokenStream {
+    quote! {
+        /// Trait representing this register block. Driver code can use this trait to work with
+        /// both real hardware and fake implementations of the peripheral (for unit testing).
+    }
+}
+
+pub fn bus_doc_comment() -> TokenStream {
+    quote! {
+        /// Buses supported by this register block.
+    }
+}
+
+pub fn real_doc_comment() -> TokenStream {
+    quote! {
+        /// Struct implementing [Interface] for use with the real hardware.
+    }
+}
+
+pub fn field_struct_doc_comment(name: &Ident) -> TokenStream {
+    let msg = format!("Struct that provides access to the `{name}` register on real hardware.");
+    quote![#[doc = #msg]]
+}
+
+/// Adds offset tests for a field with the given offsets. If the current cumulative size is unknown
+/// (because of a padding field with no specified size), this does nothing.
+fn add_offset_tests(
+    tock_registers: &Path,
+    offset_tests: &mut TokenStream,
+    buses: &[TypePath],
+    cumulative_sizes: &[TokenStream],
+    offsets: &PerBusInt,
+) {
+    for (bus_idx, cumulative_size) in cumulative_sizes.iter().enumerate() {
+        let offset = &offsets[bus_idx];
+        let bus = &buses[bus_idx].path.segments.last().expect("empty bus path");
+        let msg = format!("offset mismatch for bus {}", bus.ident);
+        offset_tests.extend(quote_spanned![offset.span()=>assert!(#offset ==
+            #tock_registers::internal::core::convert::identity(#cumulative_size), #msg);]);
+    }
+}

--- a/codegen/src/block_test_all_fields.rs
+++ b/codegen/src/block_test_all_fields.rs
@@ -1,0 +1,306 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+// Copyright Better Bytes 2026.
+
+use crate::block::{
+    bus_doc_comment, field_struct_doc_comment, interface_doc_comment, real_doc_comment,
+};
+use crate::{new_doc_comment, register_map, test_util::assert_tokens_eq, Env::ProcMacro};
+use quote::quote;
+use syn::parse_quote;
+
+/// This serves two purposes: it tests the generated code, and also serves as a walkthrough of the
+/// generated code.
+#[test]
+fn all_field_types_example() {
+    let input = quote! {
+        ::tock_registers
+        #[buses(Mmio32, Mmio64)]
+        pub foo {
+            0 => scalar_definition: u8 { Read, Dance<Waltz> },
+            1 => array_definition: [[u8; 2]; 3] { Read, Write },
+            7 => _: 1, // Padding
+            8 => scalar_reference: a,
+            9 => array_reference: [[b; 2]; 3],
+            15 => flat_array_definition: [u8; 2] { Read },
+            17 => flat_array_reference: [c; 2],
+        }
+    };
+    let interface_comment = interface_doc_comment();
+    let bus_comment = bus_doc_comment();
+    let real_comment = real_doc_comment();
+    let new_comment = new_doc_comment();
+    let scalar_definition_comment = field_struct_doc_comment(&parse_quote![scalar_definition]);
+    let array_definition_comment = field_struct_doc_comment(&parse_quote![array_definition]);
+    let flat_array_definition_comment =
+        field_struct_doc_comment(&parse_quote![flat_array_definition]);
+    let expected = quote! {
+        pub mod foo {
+            #![allow(non_camel_case_types)]
+            use super::*;
+            #interface_comment pub trait Interface: ::tock_registers::internal::core::marker::Copy {
+                type scalar_definition:
+                    ::tock_registers::Register<DataType = u8> + Read + Dance<Waltz>;
+                fn scalar_definition(self) -> Self::scalar_definition;
+                type array_definition: ::tock_registers::RegisterArray<
+                    lens::array_definition<1usize>,
+                    Element: ::tock_registers::RegisterArray<lens::array_definition<0usize>,
+                        Element: ::tock_registers::Register<DataType = u8> + Read + Write> >;
+                fn array_definition(self) -> Self::array_definition;
+                type scalar_reference: a::Interface;
+                fn scalar_reference(self) -> Self::scalar_reference;
+                type array_reference: ::tock_registers::RegisterArray<
+                    lens::array_reference<1usize>, Element: ::tock_registers::RegisterArray<
+                        lens::array_reference<0usize>, Element: b::Interface> >;
+                fn array_reference(self) -> Self::array_reference;
+                type flat_array_definition: ::tock_registers::RegisterArray<
+                    lens::flat_array_definition, Element:
+                        ::tock_registers::Register<DataType = u8> + Read>;
+                fn flat_array_definition(self) -> Self::flat_array_definition;
+                type flat_array_reference: ::tock_registers::RegisterArray<
+                    lens::flat_array_reference, Element: c::Interface>;
+                fn flat_array_reference(self) -> Self::flat_array_reference;
+            }
+            pub mod lens {
+                pub enum array_definition<const N: usize> {}
+                impl ::tock_registers::array::Len for array_definition<0usize> { const LEN: usize = 2; }
+                impl ::tock_registers::array::Len for array_definition<1usize> { const LEN: usize = 3; }
+                pub enum array_reference<const N: usize> {}
+                impl ::tock_registers::array::Len for array_reference<0usize> { const LEN: usize = 2; }
+                impl ::tock_registers::array::Len for array_reference<1usize> { const LEN: usize = 3; }
+                pub enum flat_array_definition {}
+                impl ::tock_registers::array::Len for flat_array_definition { const LEN: usize = 2; }
+                pub enum flat_array_reference {}
+                impl ::tock_registers::array::Len for flat_array_reference { const LEN: usize = 2; }
+            }
+            // We allow trait_duplication_in_bounds. For this macro to not emit duplicate bounds,
+            // it would have to parse the trait references and figure out if they are identical,
+            // which we don't want to do (we want to treat the paths as opaque to limit complexity
+            // and for future-proofing).
+            #bus_comment #[allow(clippy::trait_duplication_in_bounds)]
+            pub trait Bus: ::tock_registers::Address + ::tock_registers::DataTypeBus<u8> +
+                ::tock_registers::DataTypeBus<u8> + a::Bus + b::Bus +
+                ::tock_registers::DataTypeBus<u8> + c::Bus + sealed::Bus
+            {
+                const SIZE: usize;
+                const scalar_definition_offset: usize = 0;
+                const array_definition_offset: usize = 1;
+                const scalar_reference_offset: usize = 8;
+                const array_reference_offset: usize = 9;
+                const flat_array_definition_offset: usize = 15;
+                const flat_array_reference_offset: usize = 17;
+            }
+            impl Bus for Mmio32 {
+                const SIZE: usize = 17 + <<Real<Mmio32> as Interface>::flat_array_reference
+                    as ::tock_registers::Span>::SIZE;
+            }
+            impl sealed::Bus for Mmio32 {}
+            impl Bus for Mmio64 {
+                const SIZE: usize = 17 + <<Real<Mmio64> as Interface>::flat_array_reference
+                    as ::tock_registers::Span>::SIZE;
+            }
+            impl sealed::Bus for Mmio64 {}
+            impl<B: Bus> Bus for ::tock_registers::BorrowedBus<'_, B> {
+                const SIZE: usize = <B as Bus>::SIZE;
+            }
+            impl<B: Bus> sealed::Bus for ::tock_registers::BorrowedBus<'_, B> {}
+            const _: () = {
+                // The call to identity() in each assert! prevents the clippy::eq_op lint from
+                // triggering.
+                assert!(0 == ::tock_registers::internal::core::convert::identity(0),
+                    "offset mismatch for bus Mmio32");
+                assert!(0 == ::tock_registers::internal::core::convert::identity(0),
+                    "offset mismatch for bus Mmio64");
+                assert!(1 == ::tock_registers::internal::core::convert::identity(0 + <<Real<Mmio32>
+                    as Interface>::scalar_definition as ::tock_registers::Span>::SIZE),
+                    "offset mismatch for bus Mmio32");
+                assert!(1 == ::tock_registers::internal::core::convert::identity(0 + <<Real<Mmio64>
+                    as Interface>::scalar_definition as ::tock_registers::Span>::SIZE),
+                    "offset mismatch for bus Mmio64");
+                assert!(7 == ::tock_registers::internal::core::convert::identity(1 + <<Real<Mmio32>
+                    as Interface>::array_definition as ::tock_registers::Span>::SIZE),
+                    "offset mismatch for bus Mmio32");
+                assert!(7 == ::tock_registers::internal::core::convert::identity(1 + <<Real<Mmio64>
+                    as Interface>::array_definition as ::tock_registers::Span>::SIZE),
+                    "offset mismatch for bus Mmio64");
+                assert!(8 == ::tock_registers::internal::core::convert::identity(7 + 1),
+                    "offset mismatch for bus Mmio32");
+                assert!(8 == ::tock_registers::internal::core::convert::identity(7 + 1),
+                    "offset mismatch for bus Mmio64");
+                assert!(9 == ::tock_registers::internal::core::convert::identity(8 + <<Real<Mmio32>
+                    as Interface>::scalar_reference as ::tock_registers::Span>::SIZE),
+                    "offset mismatch for bus Mmio32");
+                assert!(9 == ::tock_registers::internal::core::convert::identity(8 + <<Real<Mmio64>
+                    as Interface>::scalar_reference as ::tock_registers::Span>::SIZE),
+                    "offset mismatch for bus Mmio64");
+                assert!(15 == ::tock_registers::internal::core::convert::identity(9 +
+                    <<Real<Mmio32> as Interface>::array_reference as ::tock_registers::Span>::SIZE),
+                    "offset mismatch for bus Mmio32");
+                assert!(15 == ::tock_registers::internal::core::convert::identity(9 +
+                    <<Real<Mmio64> as Interface>::array_reference as ::tock_registers::Span>::SIZE),
+                    "offset mismatch for bus Mmio64");
+                assert!(17 == ::tock_registers::internal::core::convert::identity(15 +
+                    <<Real<Mmio32> as Interface>::flat_array_definition
+                    as ::tock_registers::Span>::SIZE), "offset mismatch for bus Mmio32");
+                assert!(17 == ::tock_registers::internal::core::convert::identity(15 +
+                    <<Real<Mmio64> as Interface>::flat_array_definition
+                    as ::tock_registers::Span>::SIZE), "offset mismatch for bus Mmio64");
+            };
+            mod sealed { pub trait Bus {} }
+            #real_comment #[derive(Clone)] pub struct Real<B: Bus> {
+                address: B,
+                _phantom: ::tock_registers::internal::RealPhantom,
+            }
+            impl<B: Bus> Real<B> {
+                #new_comment pub const unsafe fn new(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+            }
+            impl<B: Bus> ::tock_registers::internal::core::marker::Copy for Real<B> {}
+            impl<B: Bus> Interface for Real<B>
+            where
+                real_scalar_definition<B>:
+                    ::tock_registers::Register<DataType = u8> + Read + Dance<Waltz>,
+                real_array_definition<B>: ::tock_registers::Register<DataType = u8> + Read + Write,
+                a::Real<B>: a::Interface,
+                b::Real<B>: b::Interface,
+                real_flat_array_definition<B>: ::tock_registers::Register<DataType = u8> + Read,
+                c::Real<B>: c::Interface,
+            {
+                type scalar_definition = real_scalar_definition<B>;
+                fn scalar_definition(self) -> Self::scalar_definition {
+                    unsafe {
+                        Self::scalar_definition::new(
+                            self.address.byte_add(<B as Bus>::scalar_definition_offset))
+                    }
+                }
+                type array_definition = ::tock_registers::RealRegisterArray<
+                    ::tock_registers::RealRegisterArray<real_array_definition<B>,
+                        lens::array_definition<0usize> >, lens::array_definition<1usize> >;
+                fn array_definition(self) -> Self::array_definition {
+                    unsafe {
+                        Self::array_definition::new(
+                            self.address.byte_add(<B as Bus>::array_definition_offset))
+                    }
+                }
+                type scalar_reference = a::Real<B>;
+                fn scalar_reference(self) -> Self::scalar_reference {
+                    unsafe {
+                        Self::scalar_reference::new(
+                            self.address.byte_add(<B as Bus>::scalar_reference_offset))
+                    }
+                }
+                type array_reference = ::tock_registers::RealRegisterArray<
+                    ::tock_registers::RealRegisterArray<b::Real<B>, lens::array_reference<0usize>
+                    >, lens::array_reference<1usize> >;
+                fn array_reference(self) -> Self::array_reference {
+                    unsafe {
+                        Self::array_reference::new(
+                            self.address.byte_add(<B as Bus>::array_reference_offset))
+                    }
+                }
+                type flat_array_definition = ::tock_registers::RealRegisterArray<
+                    real_flat_array_definition<B>, lens::flat_array_definition>;
+                fn flat_array_definition(self) -> Self::flat_array_definition {
+                    unsafe {
+                        Self::flat_array_definition::new(
+                            self.address.byte_add(<B as Bus>::flat_array_definition_offset))
+                    }
+                }
+                type flat_array_reference =
+                    ::tock_registers::RealRegisterArray<c::Real<B>, lens::flat_array_reference>;
+                fn flat_array_reference(self) -> Self::flat_array_reference {
+                    unsafe {
+                        Self::flat_array_reference::new(
+                            self.address.byte_add(<B as Bus>::flat_array_reference_offset))
+                    }
+                }
+            }
+            unsafe impl<B: Bus> ::tock_registers::Span for Real<B> {
+                type Address = B;
+                const SIZE: usize = <B as Bus>::SIZE;
+                unsafe fn with_addr(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+                type Borrowed<'b> = Real<::tock_registers::BorrowedBus<'b, B>>;
+            }
+            #scalar_definition_comment #[derive(Clone)] pub struct real_scalar_definition<B: Bus> {
+                address: B,
+                _phantom: ::tock_registers::internal::RealPhantom,
+            }
+            impl<B: Bus> real_scalar_definition<B> {
+                #new_comment pub const unsafe fn new(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+            }
+            impl<B: Bus> ::tock_registers::internal::core::marker::Copy
+            for real_scalar_definition<B> {}
+            unsafe impl<B: Bus> ::tock_registers::Span for real_scalar_definition<B> {
+                type Address = B;
+                const SIZE: usize = <B as ::tock_registers::DataTypeBus<u8>>::PADDED_SIZE;
+                unsafe fn with_addr(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+                type Borrowed<'b> = real_scalar_definition<::tock_registers::BorrowedBus<'b, B>>;
+            }
+            impl<B: Bus> ::tock_registers::Register for real_scalar_definition<B> {
+                type DataType = u8;
+            }
+            Read!(real_impl, real_scalar_definition, u8,,);
+            // Since macros cannot accept generic arguments, the generics are instead detached from
+            // the operation path and moved into an argument of the macro invocation.
+            Dance!(real_impl, real_scalar_definition, u8, <Waltz>,);
+            #array_definition_comment #[derive(Clone)] pub struct real_array_definition<B: Bus> {
+                address: B,
+                _phantom: ::tock_registers::internal::RealPhantom,
+            }
+            impl<B: Bus> real_array_definition<B> {
+                #new_comment pub const unsafe fn new(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+            }
+            impl<B: Bus> ::tock_registers::internal::core::marker::Copy
+            for real_array_definition<B> {}
+            unsafe impl<B: Bus> ::tock_registers::Span for real_array_definition<B> {
+                type Address = B;
+                const SIZE: usize = <B as ::tock_registers::DataTypeBus<u8>>::PADDED_SIZE;
+                unsafe fn with_addr(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+                type Borrowed<'b> = real_array_definition<::tock_registers::BorrowedBus<'b, B>>;
+            }
+            impl<B: Bus> ::tock_registers::Register for real_array_definition<B> {
+                type DataType = u8;
+            }
+            Read!(real_impl, real_array_definition, u8,,);
+            Write!(real_impl, real_array_definition, u8,,);
+            #flat_array_definition_comment #[derive(Clone)]
+            pub struct real_flat_array_definition<B: Bus> {
+                address: B,
+                _phantom: ::tock_registers::internal::RealPhantom,
+            }
+            impl<B: Bus> real_flat_array_definition<B> {
+                #new_comment pub const unsafe fn new(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+            }
+            impl<B: Bus> ::tock_registers::internal::core::marker::Copy
+            for real_flat_array_definition<B> {}
+            unsafe impl<B: Bus> ::tock_registers::Span for real_flat_array_definition<B> {
+                type Address = B;
+                const SIZE: usize = <B as ::tock_registers::DataTypeBus<u8>>::PADDED_SIZE;
+                unsafe fn with_addr(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+                type Borrowed<'b> =
+                    real_flat_array_definition<::tock_registers::BorrowedBus<'b, B>>;
+            }
+            impl<B: Bus> ::tock_registers::Register for real_flat_array_definition<B> {
+                type DataType = u8;
+            }
+            Read!(real_impl, real_flat_array_definition, u8,,);
+        }
+    };
+    assert_tokens_eq(register_map(input, ProcMacro).unwrap(), expected);
+}

--- a/codegen/src/block_test_docs.rs
+++ b/codegen/src/block_test_docs.rs
@@ -1,0 +1,284 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+// Copyright Better Bytes 2026.
+
+//! These test cases verify that:
+//!
+//! 1. Doc comments that should be copied from the input are copied correctly.
+//! 2. Generated doc comments are correct.
+
+use crate::{register_map, test_util::assert_tokens_eq, Env::ProcMacro};
+use quote::quote;
+
+#[test]
+fn doc_comments() {
+    let input = quote! {
+        ::tock_registers
+        //! Doc comment A
+        //! Doc comment B
+        #![buses(Mmio32, Mmio64)]
+        //! Doc comment C
+        //! Doc comment D
+        /// Doc comment E
+        /// Doc comment F
+        pub foo {
+            /// Doc comment G
+            /// Doc comment H
+            0 => scalar_definition: u8 { Read, Write },
+            /// Doc comment I
+            /// Doc comment J
+            1 => array_definition: [[u8; 2]; 3] { Read, Write },
+            /// Doc comment K
+            /// Doc comment L
+            7 => scalar_reference: a,
+            /// Doc comment M
+            /// Doc comment N
+            8 => array_reference: [[b; 2]; 3],
+        }
+    };
+    let expected = quote! {
+        /// Doc comment A
+        /// Doc comment B
+        /// Doc comment C
+        /// Doc comment D
+        /// Doc comment E
+        /// Doc comment F
+        pub mod foo {
+            #![allow(non_camel_case_types)]
+            use super::*;
+            /// Trait representing this register block. Driver code can use this trait to work with
+            /// both real hardware and fake implementations of the peripheral (for unit testing).
+            pub trait Interface: ::tock_registers::internal::core::marker::Copy {
+                type scalar_definition: ::tock_registers::Register<DataType = u8> + Read + Write;
+                /// Doc comment G
+                /// Doc comment H
+                fn scalar_definition(self) -> Self::scalar_definition;
+                type array_definition: ::tock_registers::RegisterArray<
+                    lens::array_definition<1usize>, Element:
+                        ::tock_registers::RegisterArray<lens::array_definition<0usize>, Element:
+                            ::tock_registers::Register<DataType = u8> + Read + Write> >;
+                /// Doc comment I
+                /// Doc comment J
+                fn array_definition(self) -> Self::array_definition;
+                type scalar_reference: a::Interface;
+                /// Doc comment K
+                /// Doc comment L
+                fn scalar_reference(self) -> Self::scalar_reference;
+                type array_reference: ::tock_registers::RegisterArray<
+                    lens::array_reference<1usize>, Element: ::tock_registers::RegisterArray<
+                        lens::array_reference<0usize>, Element: b::Interface> >;
+                /// Doc comment M
+                /// Doc comment N
+                fn array_reference(self) -> Self::array_reference;
+            }
+            pub mod lens {
+                pub enum array_definition<const N: usize> {}
+                impl ::tock_registers::array::Len for
+                    array_definition<0usize> { const LEN: usize = 2; }
+                impl ::tock_registers::array::Len for
+                    array_definition<1usize> { const LEN: usize = 3; }
+                pub enum array_reference<const N: usize> {}
+                impl ::tock_registers::array::Len for
+                    array_reference<0usize> { const LEN: usize = 2; }
+                impl ::tock_registers::array::Len for
+                    array_reference<1usize> { const LEN: usize = 3; }
+            }
+            /// Buses supported by this register block.
+            #[allow(clippy::trait_duplication_in_bounds)]
+            pub trait Bus: ::tock_registers::Address + ::tock_registers::DataTypeBus<u8> +
+                ::tock_registers::DataTypeBus<u8> + a::Bus + b::Bus + sealed::Bus
+            {
+                const SIZE: usize;
+                const scalar_definition_offset: usize = 0;
+                const array_definition_offset: usize = 1;
+                const scalar_reference_offset: usize = 7;
+                const array_reference_offset: usize = 8;
+            }
+            impl Bus for Mmio32 {
+                const SIZE: usize = 8 +
+                    <<Real<Mmio32> as Interface>::array_reference as ::tock_registers::Span>::SIZE;
+            }
+            impl sealed::Bus for Mmio32 {}
+            impl Bus for Mmio64 {
+                const SIZE: usize = 8 +
+                    <<Real<Mmio64> as Interface>::array_reference as ::tock_registers::Span>::SIZE;
+            }
+            impl sealed::Bus for Mmio64 {}
+            impl<B: Bus> Bus for ::tock_registers::BorrowedBus<'_, B> {
+                const SIZE: usize = <B as Bus>::SIZE;
+            }
+            impl<B: Bus> sealed::Bus for ::tock_registers::BorrowedBus<'_, B> {}
+            const _: () = {
+                assert!(0 == ::tock_registers::internal::core::convert::identity(0),
+                    "offset mismatch for bus Mmio32");
+                assert!(0 == ::tock_registers::internal::core::convert::identity(0),
+                    "offset mismatch for bus Mmio64");
+                assert!(1 == ::tock_registers::internal::core::convert::identity(0 + <<Real<Mmio32>
+                    as Interface>::scalar_definition as ::tock_registers::Span>::SIZE),
+                    "offset mismatch for bus Mmio32");
+                assert!(1 == ::tock_registers::internal::core::convert::identity(0 + <<Real<Mmio64>
+                    as Interface>::scalar_definition as ::tock_registers::Span>::SIZE),
+                    "offset mismatch for bus Mmio64");
+                assert!(7 == ::tock_registers::internal::core::convert::identity(1 + <<Real<Mmio32>
+                    as Interface>::array_definition as ::tock_registers::Span>::SIZE),
+                    "offset mismatch for bus Mmio32");
+                assert!(7 == ::tock_registers::internal::core::convert::identity(1 + <<Real<Mmio64>
+                    as Interface>::array_definition as ::tock_registers::Span>::SIZE),
+                    "offset mismatch for bus Mmio64");
+                assert!(8 == ::tock_registers::internal::core::convert::identity(7 + <<Real<Mmio32>
+                    as Interface>::scalar_reference as ::tock_registers::Span>::SIZE),
+                    "offset mismatch for bus Mmio32");
+                assert!(8 == ::tock_registers::internal::core::convert::identity(7 + <<Real<Mmio64>
+                    as Interface>::scalar_reference as ::tock_registers::Span>::SIZE),
+                    "offset mismatch for bus Mmio64");
+            };
+            mod sealed { pub trait Bus {} }
+            /// Struct implementing [Interface] for use with the real hardware.
+            #[derive(Clone)] pub struct Real<B: Bus> {
+                address: B,
+                _phantom: ::tock_registers::internal::RealPhantom,
+            }
+            impl<B: Bus> Real<B> {
+                /// Constructs an accessor for this register or register block.
+                /// # Safety
+                /// 1. `address` must point to register(s) on the bus corresponding to
+                ///    `B`.
+                /// 2. The register(s)' definition (as provided to the
+                ///    `tock_registers::register_map!` macro) must correctly
+                ///    describe the pointed-to register(s).
+                /// 3. The returned register accessor must not be used in a way that
+                ///    causes data races. The exact requirements depend on the hardware,
+                ///    but it's usually best to access a register from only one thread
+                ///    at a time.
+                pub const unsafe fn new(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+            }
+            impl<B: Bus> ::tock_registers::internal::core::marker::Copy for Real<B> {}
+            impl<B: Bus> Interface for Real<B>
+            where
+                real_scalar_definition<B>: ::tock_registers::Register<DataType = u8> + Read + Write,
+                real_array_definition<B>: ::tock_registers::Register<DataType = u8> + Read + Write,
+                a::Real<B>: a::Interface,
+                b::Real<B>: b::Interface,
+            {
+                type scalar_definition = real_scalar_definition<B>;
+                fn scalar_definition(self) -> Self::scalar_definition {
+                    unsafe {
+                        Self::scalar_definition::new(
+                            self.address.byte_add(<B as Bus>::scalar_definition_offset))
+                    }
+                }
+                type array_definition = ::tock_registers::RealRegisterArray<
+                    ::tock_registers::RealRegisterArray<real_array_definition<B>,
+                    lens::array_definition<0usize> >, lens::array_definition<1usize> >;
+                fn array_definition(self) -> Self::array_definition {
+                    unsafe {
+                        Self::array_definition::new(
+                            self.address.byte_add(<B as Bus>::array_definition_offset))
+                    }
+                }
+                type scalar_reference = a::Real<B>;
+                fn scalar_reference(self) -> Self::scalar_reference {
+                    unsafe {
+                        Self::scalar_reference::new(
+                            self.address.byte_add(<B as Bus>::scalar_reference_offset))
+                    }
+                }
+                type array_reference = ::tock_registers::RealRegisterArray<
+                    ::tock_registers::RealRegisterArray<b::Real<B>, lens::array_reference<0usize>
+                    >, lens::array_reference<1usize> >;
+                fn array_reference(self) -> Self::array_reference {
+                    unsafe {
+                        Self::array_reference::new(
+                            self.address.byte_add(<B as Bus>::array_reference_offset))
+                    }
+                }
+            }
+            unsafe impl<B: Bus> ::tock_registers::Span for Real<B> {
+                type Address = B;
+                const SIZE: usize = <B as Bus>::SIZE;
+                unsafe fn with_addr(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+                type Borrowed<'b> = Real<::tock_registers::BorrowedBus<'b, B>>;
+            }
+            #[doc =
+                "Struct that provides access to the `scalar_definition` register on real hardware."]
+            #[derive(Clone)] pub struct real_scalar_definition<B: Bus> {
+                address: B,
+                _phantom: ::tock_registers::internal::RealPhantom,
+            }
+            impl<B: Bus> real_scalar_definition<B> {
+                /// Constructs an accessor for this register or register block.
+                /// # Safety
+                /// 1. `address` must point to register(s) on the bus corresponding to
+                ///    `B`.
+                /// 2. The register(s)' definition (as provided to the
+                ///    `tock_registers::register_map!` macro) must correctly
+                ///    describe the pointed-to register(s).
+                /// 3. The returned register accessor must not be used in a way that
+                ///    causes data races. The exact requirements depend on the hardware,
+                ///    but it's usually best to access a register from only one thread
+                ///    at a time.
+                pub const unsafe fn new(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+            }
+            impl<B: Bus> ::tock_registers::internal::core::marker::Copy
+            for real_scalar_definition<B> {}
+            unsafe impl<B: Bus> ::tock_registers::Span for real_scalar_definition<B> {
+                type Address = B;
+                const SIZE: usize = <B as ::tock_registers::DataTypeBus<u8>>::PADDED_SIZE;
+                unsafe fn with_addr(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+                type Borrowed<'b> = real_scalar_definition<::tock_registers::BorrowedBus<'b, B>>;
+            }
+            impl<B: Bus> ::tock_registers::Register for real_scalar_definition<B> {
+                type DataType = u8;
+            }
+            Read!(real_impl, real_scalar_definition, u8,,);
+            Write!(real_impl, real_scalar_definition, u8,,);
+            #[doc =
+                "Struct that provides access to the `array_definition` register on real hardware."]
+            #[derive(Clone)] pub struct real_array_definition<B: Bus> {
+                address: B,
+                _phantom: ::tock_registers::internal::RealPhantom,
+            }
+            impl<B: Bus> real_array_definition<B> {
+                /// Constructs an accessor for this register or register block.
+                /// # Safety
+                /// 1. `address` must point to register(s) on the bus corresponding to
+                ///    `B`.
+                /// 2. The register(s)' definition (as provided to the
+                ///    `tock_registers::register_map!` macro) must correctly
+                ///    describe the pointed-to register(s).
+                /// 3. The returned register accessor must not be used in a way that
+                ///    causes data races. The exact requirements depend on the hardware,
+                ///    but it's usually best to access a register from only one thread
+                ///    at a time.
+                pub const unsafe fn new(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+            }
+            impl<B: Bus> ::tock_registers::internal::core::marker::Copy
+            for real_array_definition<B> {}
+            unsafe impl<B: Bus> ::tock_registers::Span for real_array_definition<B> {
+                type Address = B;
+                const SIZE: usize = <B as ::tock_registers::DataTypeBus<u8>>::PADDED_SIZE;
+                unsafe fn with_addr(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+                type Borrowed<'b> = real_array_definition<::tock_registers::BorrowedBus<'b, B>>;
+            }
+            impl<B: Bus> ::tock_registers::Register for real_array_definition<B> {
+                type DataType = u8;
+            }
+            Read!(real_impl, real_array_definition, u8,,);
+            Write!(real_impl, real_array_definition, u8,,);
+        }
+    };
+    assert_tokens_eq(register_map(input, ProcMacro).unwrap(), expected);
+}

--- a/codegen/src/block_test_empty.rs
+++ b/codegen/src/block_test_empty.rs
@@ -1,0 +1,62 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+// Copyright Better Bytes 2026.
+
+use crate::block::{bus_doc_comment, interface_doc_comment, real_doc_comment};
+use crate::{new_doc_comment, register_map, test_util::assert_tokens_eq, Env::External};
+use quote::quote;
+
+// This also doubles as the test for Env::External code generation.
+#[test]
+fn empty() {
+    let input = quote! {
+        ::tock_registers
+        #[bus(Mmio32)]
+        pub foo {}
+    };
+    let interface_comment = interface_doc_comment();
+    let bus_comment = bus_doc_comment();
+    let real_comment = real_doc_comment();
+    let new_comment = new_doc_comment();
+    let expected = quote! {
+        pub mod foo {
+            #![allow(non_camel_case_types,dead_code,non_upper_case_globals)] use super::*;
+            #interface_comment
+            pub trait Interface: ::tock_registers::internal::core::marker::Copy {}
+            pub mod lens {}
+            #bus_comment #[allow(clippy::trait_duplication_in_bounds)]
+            pub trait Bus: ::tock_registers::Address + sealed::Bus {
+                const SIZE: usize;
+            }
+            impl Bus for Mmio32 { const SIZE: usize = 0; }
+            impl sealed::Bus for Mmio32 {}
+            impl<B: Bus> Bus for ::tock_registers::BorrowedBus<'_, B> {
+                const SIZE: usize = <B as Bus>::SIZE;
+            }
+            impl<B: Bus> sealed::Bus for ::tock_registers::BorrowedBus<'_, B> {}
+            const _: () = {};
+            mod sealed { pub trait Bus {} }
+            #real_comment #[derive(Clone)] pub struct Real<B: Bus = Mmio32> {
+                address: B,
+                _phantom: ::tock_registers::internal::RealPhantom,
+            }
+            impl<B: Bus> Real<B> {
+                #new_comment pub const unsafe fn new(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+            }
+            impl<B: Bus> ::tock_registers::internal::core::marker::Copy for Real<B> {}
+            impl<B: Bus> Interface for Real<B> where {}
+            unsafe impl<B: Bus> ::tock_registers::Span for Real<B> {
+                type Address = B;
+                const SIZE: usize = <B as Bus>::SIZE;
+                unsafe fn with_addr(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+                type Borrowed<'b> = Real<::tock_registers::BorrowedBus<'b, B>>;
+            }
+        }
+    };
+    assert_tokens_eq(register_map(input, External).unwrap(), expected);
+}

--- a/codegen/src/block_test_offsets.rs
+++ b/codegen/src/block_test_offsets.rs
@@ -1,0 +1,295 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+// Copyright Better Bytes 2026.
+
+use crate::block::{
+    bus_doc_comment, field_struct_doc_comment, interface_doc_comment, real_doc_comment,
+};
+use crate::{new_doc_comment, register_map, test_util::assert_tokens_eq, Env::ProcMacro};
+use quote::quote;
+use syn::parse_quote;
+
+#[test]
+fn offsets() {
+    let input = quote! {
+        ::tock_registers
+        #[buses(Mmio32, Mmio64)]
+        pub foo {
+            0 => variable_size: usize { Read },
+            [4, 8] => size_variable_pos: u32 { Read },
+            #[aliased]
+            6 => aliased: u16 { Read },
+            [8, 12] => _: [4, 0],
+            12 => fixed_pos: u32 { Read },
+            16 => _,
+            [20, 24] => padded_pos: u8 { Read },
+            // This pattern of inferred-size padding followed by explicit-size padding is weird and
+            // probably won't be used in practice, but it allows for the total size of the block to
+            // be specified without having to specify the size of the trailing padding.
+            [21, 25] => _,
+            [24, 32] => _: 0,
+        }
+    };
+    let interface_comment = interface_doc_comment();
+    let bus_comment = bus_doc_comment();
+    let real_comment = real_doc_comment();
+    let new_comment = new_doc_comment();
+    let variable_size_comment = field_struct_doc_comment(&parse_quote![variable_size]);
+    let size_variable_pos_comment = field_struct_doc_comment(&parse_quote![size_variable_pos]);
+    let aliased_comment = field_struct_doc_comment(&parse_quote![aliased]);
+    let fixed_pos_comment = field_struct_doc_comment(&parse_quote![fixed_pos]);
+    let padded_pos_comment = field_struct_doc_comment(&parse_quote![padded_pos]);
+    let expected = quote! {
+        pub mod foo {
+            #![allow(non_camel_case_types)]
+            use super::*;
+            #interface_comment pub trait Interface: ::tock_registers::internal::core::marker::Copy {
+                type variable_size: ::tock_registers::Register<DataType = usize> + Read;
+                fn variable_size(self) -> Self::variable_size;
+                type size_variable_pos: ::tock_registers::Register<DataType = u32> + Read;
+                fn size_variable_pos(self) -> Self::size_variable_pos;
+                type aliased: ::tock_registers::Register<DataType = u16> + Read;
+                fn aliased(self) -> Self::aliased;
+                type fixed_pos: ::tock_registers::Register<DataType = u32> + Read;
+                fn fixed_pos(self) -> Self::fixed_pos;
+                type padded_pos: ::tock_registers::Register<DataType = u8> + Read;
+                fn padded_pos(self) -> Self::padded_pos;
+            }
+            pub mod lens {}
+            #bus_comment #[allow(clippy::trait_duplication_in_bounds)]
+            pub trait Bus: ::tock_registers::Address + ::tock_registers::DataTypeBus<usize> +
+                ::tock_registers::DataTypeBus<u32> + ::tock_registers::DataTypeBus<u16> +
+                ::tock_registers::DataTypeBus<u32> + ::tock_registers::DataTypeBus<u8> + sealed::Bus
+            {
+                const SIZE: usize;
+                const variable_size_offset: usize = 0;
+                const size_variable_pos_offset: usize;
+                const aliased_offset: usize = 6;
+                const fixed_pos_offset: usize = 12;
+                const padded_pos_offset: usize;
+            }
+            impl Bus for Mmio32 {
+                const SIZE: usize = 24 + 0;
+                const size_variable_pos_offset: usize = 4;
+                const padded_pos_offset: usize = 20;
+            }
+            impl sealed::Bus for Mmio32 {}
+            impl Bus for Mmio64 {
+                const SIZE: usize = 32 + 0;
+                const size_variable_pos_offset: usize = 8;
+                const padded_pos_offset: usize = 24;
+            }
+            impl sealed::Bus for Mmio64 {}
+            impl<B: Bus> Bus for ::tock_registers::BorrowedBus<'_, B> {
+                const SIZE: usize = <B as Bus>::SIZE;
+                const size_variable_pos_offset: usize = <B as Bus>::size_variable_pos_offset;
+                const padded_pos_offset: usize = <B as Bus>::padded_pos_offset;
+            }
+            impl<B: Bus> sealed::Bus for ::tock_registers::BorrowedBus<'_, B> {}
+            const _: () = {
+                assert!(0 == ::tock_registers::internal::core::convert::identity(0),
+                    "offset mismatch for bus Mmio32");
+                assert!(0 == ::tock_registers::internal::core::convert::identity(0),
+                    "offset mismatch for bus Mmio64");
+                assert!(4 == ::tock_registers::internal::core::convert::identity(0 +
+                    <<Real<Mmio32> as Interface>::variable_size as ::tock_registers::Span>::SIZE),
+                    "offset mismatch for bus Mmio32");
+                assert!(8 == ::tock_registers::internal::core::convert::identity(0 +
+                    <<Real<Mmio64> as Interface>::variable_size as ::tock_registers::Span>::SIZE),
+                    "offset mismatch for bus Mmio64");
+                assert!(8 == ::tock_registers::internal::core::convert::identity(4 + <<Real<Mmio32>
+                    as Interface>::size_variable_pos as ::tock_registers::Span>::SIZE),
+                    "offset mismatch for bus Mmio32");
+                assert!(12 == ::tock_registers::internal::core::convert::identity(8 + <<Real<Mmio64>
+                    as Interface>::size_variable_pos as ::tock_registers::Span>::SIZE),
+                    "offset mismatch for bus Mmio64");
+                assert!(12 == ::tock_registers::internal::core::convert::identity(8 + 4),
+                    "offset mismatch for bus Mmio32");
+                assert!(12 == ::tock_registers::internal::core::convert::identity(12 + 0),
+                    "offset mismatch for bus Mmio64");
+                assert!(16 == ::tock_registers::internal::core::convert::identity(12 +
+                    <<Real<Mmio32> as Interface>::fixed_pos as ::tock_registers::Span>::SIZE),
+                    "offset mismatch for bus Mmio32");
+                assert!(16 == ::tock_registers::internal::core::convert::identity(12 +
+                    <<Real<Mmio64> as Interface>::fixed_pos as ::tock_registers::Span>::SIZE),
+                    "offset mismatch for bus Mmio64");
+                assert!(21 == ::tock_registers::internal::core::convert::identity(20 +
+                    <<Real<Mmio32> as Interface>::padded_pos as ::tock_registers::Span>::SIZE),
+                    "offset mismatch for bus Mmio32");
+                assert!(25 == ::tock_registers::internal::core::convert::identity(24 +
+                    <<Real<Mmio64> as Interface>::padded_pos as ::tock_registers::Span>::SIZE),
+                    "offset mismatch for bus Mmio64");
+            };
+            mod sealed { pub trait Bus {} }
+            #real_comment #[derive(Clone)] pub struct Real<B: Bus> {
+                address: B,
+                _phantom: ::tock_registers::internal::RealPhantom,
+            }
+            impl<B: Bus> Real<B> {
+                #new_comment pub const unsafe fn new(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+            }
+            impl<B: Bus> ::tock_registers::internal::core::marker::Copy for Real<B> {}
+            impl<B: Bus> Interface for Real<B>
+            where
+                real_variable_size<B>: ::tock_registers::Register<DataType = usize> + Read,
+                real_size_variable_pos<B>: ::tock_registers::Register<DataType = u32> + Read,
+                real_aliased<B>: ::tock_registers::Register<DataType = u16> + Read,
+                real_fixed_pos<B>: ::tock_registers::Register<DataType = u32> + Read,
+                real_padded_pos<B>: ::tock_registers::Register<DataType = u8> + Read,
+            {
+                type variable_size = real_variable_size<B>;
+                fn variable_size(self) -> Self::variable_size {
+                    unsafe {
+                        Self::variable_size::new(
+                            self.address.byte_add(<B as Bus>::variable_size_offset))
+                    }
+                }
+                type size_variable_pos = real_size_variable_pos<B>;
+                fn size_variable_pos(self) -> Self::size_variable_pos {
+                    unsafe {
+                        Self::size_variable_pos::new(
+                            self.address.byte_add(<B as Bus>::size_variable_pos_offset))
+                    }
+                }
+                type aliased = real_aliased<B>;
+                fn aliased(self) -> Self::aliased {
+                    unsafe { Self::aliased::new(self.address.byte_add(<B as Bus>::aliased_offset)) }
+                }
+                type fixed_pos = real_fixed_pos<B>;
+                fn fixed_pos(self) -> Self::fixed_pos {
+                    unsafe {
+                        Self::fixed_pos::new(self.address.byte_add(<B as Bus>::fixed_pos_offset))
+                    }
+                }
+                type padded_pos = real_padded_pos<B>;
+                fn padded_pos(self) -> Self::padded_pos {
+                    unsafe {
+                        Self::padded_pos::new(self.address.byte_add(<B as Bus>::padded_pos_offset))
+                    }
+                }
+            }
+            unsafe impl<B: Bus> ::tock_registers::Span for Real<B> {
+                type Address = B;
+                const SIZE: usize = <B as Bus>::SIZE;
+                unsafe fn with_addr(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+                type Borrowed<'b> = Real<::tock_registers::BorrowedBus<'b, B>>;
+            }
+            #variable_size_comment #[derive(Clone)] pub struct real_variable_size<B: Bus> {
+                address: B,
+                _phantom: ::tock_registers::internal::RealPhantom,
+            }
+            impl<B: Bus> real_variable_size<B> {
+                #new_comment pub const unsafe fn new(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+            }
+            impl<B: Bus> ::tock_registers::internal::core::marker::Copy for real_variable_size<B> {}
+            unsafe impl<B: Bus> ::tock_registers::Span for real_variable_size<B> {
+                type Address = B;
+                const SIZE: usize = <B as ::tock_registers::DataTypeBus<usize>>::PADDED_SIZE;
+                unsafe fn with_addr(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+                type Borrowed<'b> = real_variable_size<::tock_registers::BorrowedBus<'b, B>>;
+            }
+            impl<B: Bus> ::tock_registers::Register for real_variable_size<B> {
+                type DataType = usize;
+            }
+            Read!(real_impl, real_variable_size, usize,,);
+            #size_variable_pos_comment #[derive(Clone)] pub struct real_size_variable_pos<B: Bus> {
+                address: B,
+                _phantom: ::tock_registers::internal::RealPhantom,
+            }
+            impl<B: Bus> real_size_variable_pos<B> {
+                #new_comment pub const unsafe fn new(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+            }
+            impl<B: Bus> ::tock_registers::internal::core::marker::Copy for real_size_variable_pos<B> {}
+            unsafe impl<B: Bus> ::tock_registers::Span for real_size_variable_pos<B> {
+                type Address = B;
+                const SIZE: usize = <B as ::tock_registers::DataTypeBus<u32>>::PADDED_SIZE;
+                unsafe fn with_addr(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+                type Borrowed<'b> = real_size_variable_pos<::tock_registers::BorrowedBus<'b, B>>;
+            }
+            impl<B: Bus> ::tock_registers::Register for real_size_variable_pos<B> {
+                type DataType = u32;
+            }
+            Read!(real_impl, real_size_variable_pos, u32,,);
+            #aliased_comment #[derive(Clone)] pub struct real_aliased<B: Bus> {
+                address: B,
+                _phantom: ::tock_registers::internal::RealPhantom,
+            }
+            impl<B: Bus> real_aliased<B> {
+                #new_comment pub const unsafe fn new(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+            }
+            impl<B: Bus> ::tock_registers::internal::core::marker::Copy for real_aliased<B> {}
+            unsafe impl<B: Bus> ::tock_registers::Span for real_aliased<B> {
+                type Address = B;
+                const SIZE: usize = <B as ::tock_registers::DataTypeBus<u16>>::PADDED_SIZE;
+                unsafe fn with_addr(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+                type Borrowed<'b> = real_aliased<::tock_registers::BorrowedBus<'b, B>>;
+            }
+            impl<B: Bus> ::tock_registers::Register for real_aliased<B> { type DataType = u16; }
+            Read!(real_impl, real_aliased, u16,,);
+            #fixed_pos_comment #[derive(Clone)] pub struct real_fixed_pos<B: Bus> {
+                address: B,
+                _phantom: ::tock_registers::internal::RealPhantom,
+            }
+            impl<B: Bus> real_fixed_pos<B> {
+                #new_comment pub const unsafe fn new(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+            }
+            impl<B: Bus> ::tock_registers::internal::core::marker::Copy
+            for real_fixed_pos<B> {}
+            unsafe impl<B: Bus> ::tock_registers::Span for real_fixed_pos<B> {
+                type Address = B;
+                const SIZE: usize = <B as ::tock_registers::DataTypeBus<u32>>::PADDED_SIZE;
+                unsafe fn with_addr(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+                type Borrowed<'b> = real_fixed_pos<::tock_registers::BorrowedBus<'b, B>>;
+            }
+            impl<B: Bus> ::tock_registers::Register for real_fixed_pos<B> {
+                type DataType = u32;
+            }
+            Read!(real_impl, real_fixed_pos, u32,,);
+            #padded_pos_comment #[derive(Clone)] pub struct real_padded_pos<B: Bus> {
+                address: B,
+                _phantom: ::tock_registers::internal::RealPhantom,
+            }
+            impl<B: Bus> real_padded_pos<B> {
+                #new_comment pub const unsafe fn new(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+            }
+            impl<B: Bus> ::tock_registers::internal::core::marker::Copy
+            for real_padded_pos<B> {}
+            unsafe impl<B: Bus> ::tock_registers::Span for real_padded_pos<B> {
+                type Address = B;
+                const SIZE: usize = <B as ::tock_registers::DataTypeBus<u8>>::PADDED_SIZE;
+                unsafe fn with_addr(address: B) -> Self {
+                    Self { address, _phantom: ::tock_registers::internal::RealPhantom::new() }
+                }
+                type Borrowed<'b> = real_padded_pos<::tock_registers::BorrowedBus<'b, B>>;
+            }
+            impl<B: Bus> ::tock_registers::Register for real_padded_pos<B> {
+                type DataType = u8;
+            }
+            Read!(real_impl, real_padded_pos, u8,,);
+        }
+    };
+    assert_tokens_eq(register_map(input, ProcMacro).unwrap(), expected);
+}

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -12,6 +12,15 @@
 //    cases.
 
 mod ast;
+mod block;
+#[cfg(all(test, not(miri)))]
+mod block_test_all_fields;
+#[cfg(all(test, not(miri)))]
+mod block_test_docs;
+#[cfg(all(test, not(miri)))]
+mod block_test_empty;
+#[cfg(all(test, not(miri)))]
+mod block_test_offsets;
 mod parse;
 #[cfg(all(test, not(miri)))]
 mod parse_tests;
@@ -42,7 +51,7 @@ pub fn register_map(input: TokenStream, env: Env) -> Result<TokenStream, TokenSt
     let mut out = TokenStream::new();
     for layout in input.layouts {
         out.extend(match &layout.value {
-            Block(_fields) => quote![],    // TODO: Implement block generation
+            Block(fields) => block::generate(env, &input.tock_registers, &layout, fields),
             Single(_register) => quote![], // TODO: Implement single generation
         });
     }


### PR DESCRIPTION
This generates code for register blocks (which will be most uses of `register_map!`), along with unit tests.