### PR TITLE
Add the `register_map!` macro.

### DIFF
--- a/codegen/src/ast.rs
+++ b/codegen/src/ast.rs
@@ -5,8 +5,6 @@
 
 //! The Abstract Syntax Tree for a register_map! invocation.
 
-// TODO: Remove `ignore` from the doc tests once the macros and Read/Write ops have been merged.
-
 use proc_macro2::TokenStream;
 use quote::quote;
 use std::{ops::Index, slice};
@@ -18,7 +16,7 @@ use syn::{Attribute, Ident, LitInt, Path, Type, TypePath, Visibility};
 /// so that the generated code can refer to tock_registers even if the user has renamed the crate.
 /// Therefore, after `tock_registers::register_map!` is expanded, the full input looks like:
 ///
-/// ```ignore
+/// ```
 /// # use tock_registers::{Mmio32, Read, Write};
 /// # fn main() {}
 /// tock_registers::internal::register_map! {
@@ -48,7 +46,7 @@ pub struct Input {
 
 /// An individual register or register block layout.
 ///
-/// ```ignore
+/// ```
 /// # use tock_registers::{Read, Write};
 /// # fn main() {}
 /// tock_registers::mmio32_register_map! {
@@ -121,7 +119,7 @@ impl BusAttr {
 /// For individual register layouts, this starts with the colon, and in register blocks this begins
 /// with the opening brace.
 ///
-/// ```ignore
+/// ```
 /// # use tock_registers::{Read, Write};
 /// # fn main() {}
 /// tock_registers::mmio32_register_map! {
@@ -150,7 +148,7 @@ pub enum Value {
 
 /// An individual field in a register block. A Field can be padding or a register.
 ///
-/// ```ignore
+/// ```
 /// # use tock_registers::{Read, Write};
 /// # fn main() {}
 /// tock_registers::mmio32_register_map! {
@@ -183,7 +181,7 @@ pub struct Field {
 /// Note that when a FieldDef::Register is initially parsed, `aliased` is always false and `docs`
 /// is always empty. The Parse impl on Field sets those fields.
 ///
-/// ```ignore
+/// ```
 /// # use tock_registers::Read;
 /// # fn main() {}
 /// tock_registers::mmio32_register_map! {
@@ -220,7 +218,7 @@ pub enum FieldDef {
 /// value, which applies to all buses, or an array of values. The number of values in the array
 /// must match the number of buses.
 ///
-/// ```ignore
+/// ```
 /// # use tock_registers::{Mmio32, Mmio64, Read, Write};
 /// # fn main() {}
 /// tock_registers::register_map! {
@@ -267,7 +265,7 @@ impl Index<usize> for PerBusInt {
 /// reference (whic refers to a register definition elsewhere). The RegisterSpec begins immediately
 /// after the register's name (i.e. it includes the ':').
 ///
-/// ```ignore
+/// ```
 /// # use tock_registers::{Read, Write};
 /// # fn main() {}
 /// tock_registers::mmio32_register_map! {

--- a/src/array.rs
+++ b/src/array.rs
@@ -44,8 +44,7 @@ pub trait RegisterArray<L: Len>: Copy {
 /// }
 /// ```
 /// However, when you have a nested array in a register block:
-// TODO: Remove `ignore` once mmio32_register_map exists.
-/// ```ignore
+/// ```
 /// # fn main() {}
 /// # use tock_registers::{mmio32_register_map, Read, Write};
 /// mmio32_register_map! {
@@ -77,8 +76,7 @@ pub trait RegisterArray<L: Len>: Copy {
 ///
 /// This issue can pass through the `Interface` traits, so simply banning nested array fields does
 /// not solve the issue:
-// TODO: Remove `ignore` once mmio32_register_map exists.
-/// ```ignore
+/// ```
 /// # fn main() {}
 /// # use tock_registers::{mmio32_register_map, Read, Write};
 /// mmio32_register_map! {

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -64,8 +64,7 @@ pub unsafe trait Span: Copy {
     /// # Safety
     /// 1. `address` must point to register(s) on the bus corresponding to `Self::Address`.
     /// 2. The register(s)' definition (as provided to the
-    // TODO: Link `register_map! using [`register_map!`](crate::register_map).
-    ///    `register_map` macro) must correctly describe the pointed-to
+    ///    [`register_map`](crate::register_map) macro) must correctly describe the pointed-to
     ///    register(s).
     /// 3. The returned register span accessor must not be used in a way that causes data races.
     ///    The exact requirements depend on the hardware, but it's usually best to access a
@@ -166,8 +165,7 @@ where
     /// # Safety
     /// 1. `address` must point to register(s) on the bus corresponding to `Self::Address`.
     /// 2. The register(s)' definition (as provided to the
-    // TODO: Link `register_map! using [`register_map!`](crate::register_map).
-    ///    `register_map` macro) must correctly describe the pointed-to
+    ///    [`register_map`](crate::register_map) macro) must correctly describe the pointed-to
     ///    register(s).
     /// 3. Nothing other than handles returned by [`borrow`](Self::borrow) (and handles derived
     ///    from them) may be used to access this register span.

--- a/src/data_type.rs
+++ b/src/data_type.rs
@@ -7,8 +7,7 @@ use crate::{RegisterLongName, UIntLike};
 
 /// Trait implemented by accessors for individual registers.
 pub trait Register: Copy {
-    // TODO: Link `register_map! using [`register_map!`](crate::register_map).
-    /// This register's data type, as specified in `register_map!`'s input.
+    /// This register's data type, as specified in [`register_map!`](crate::register_map)'s input.
     type DataType: DataType;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,9 @@ pub use local_register::LocalRegisterCopy;
 
 pub mod macros;
 
+#[cfg(all(feature = "proc_macros", feature = "register_types"))]
+mod map;
+
 #[cfg(feature = "register_types")]
 mod mmio;
 #[cfg(feature = "register_types")]

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,0 +1,299 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+// Copyright Better Bytes 2026.
+
+/// Macro that defines registers and register blocks (peripherals). See `README.md` for a
+/// high-level overview; this documentation is an in-depth explanation of `register_map!`'s
+/// capabilities.
+///
+/// # The simplest example: a scalar primitive register.
+/// A basic register definition looks like:
+/// ```
+/// # fn main() {}
+/// use tock_registers::{register_map, Mmio32, Read, Write};
+/// register_map! {
+///     #[bus(Mmio32)]
+///     ctrl: u8 { Read, Write },
+/// }
+/// ```
+/// This declares an MMIO register (for 32-bit systems) called `ctrl`, whose data type is `u8`,
+/// which can be read from or written to. This definition generates a module that contains the
+/// following items:
+/// ```
+/// # fn main() {}
+/// # use tock_registers::{Mmio32, Read, Write};
+/// mod ctrl {
+///     use super::*;
+///     pub trait Interface: tock_registers::Register<DataType = u8> + Read + Write {}
+///     pub trait Bus {}
+///     impl Bus for Mmio32 {}
+///     #[derive(Clone, Copy)]
+///     pub struct Real<B: Bus = Mmio32>(B);
+/// }
+/// ```
+/// Note that many details, such as trait bounds and trait sealing, are omitted for clarity. `Real`
+/// implements several traits: [`Span`](crate::Span), [`Read`], [`Write`], and `Interface`.
+///
+/// To use the generated register type, use `Real::new` to construct a handle that points to the
+/// register, then use the [`Read`] and/or [`Write`] traits to access the register.
+///
+/// To unit test code that uses the generated register, modify the code that you want to test so
+/// that it takes a `C: ctrl::Interface` rather than a `Real`. Then, in the unit test, you can pass
+// TODO: Link FakeRegister using [`FakeRegister`](crate::FakeRegister)
+/// in a `FakeRegister` with whatever behavior the test case needs. See
+/// `doc/UnitTesting.md` in the tock-registers repository for more information.
+///
+/// # mmio32_register_map and mmio64_register_map
+/// Instead of writing `#[bus(Mmio32)]` or `#[bus(Mmio64)]` every time you call `register_map!`,
+/// you can use [`mmio32_register_map!`](crate::mmio32_register_map) or
+/// [`mmio64_register_map!`](crate::mmio64_register_map). The rest of the examples on this page
+/// will use `mmio32_register_map` for brevity.
+///
+/// # Bitfield registers
+/// A register's type can be a bitfield:
+/// ```
+/// # fn main() {}
+/// use tock_registers::{mmio32_register_map, register_bitfields, Read, Write};
+/// register_bitfields! [u8,
+///     Control [OFF 0, ON 1],
+/// ];
+/// mmio32_register_map![ctrl: Control::Register { Read, Write }];
+/// ```
+///
+/// # Register arrays
+/// You can define register arrays as well:
+/// ```
+/// # fn main() {}
+/// use tock_registers::{mmio32_register_map, Read, Write};
+/// mmio32_register_map![buttons: [u8; 8] { Read }];
+/// // You can nest array types as well.
+/// mmio32_register_map![led_grid: [[u8; 8]; 8] { Read, Write }];
+/// ```
+/// In the generated module, the `Interface` trait will depend on
+/// [`RegisterArray`](crate::RegisterArray) instead of `Register`, and the `RegisterArray::Element`
+/// type will be `Read` and/or `Write`.
+///
+/// # Register references
+/// Registers can be references to other registers:
+/// ```
+/// # fn main() {}
+/// use tock_registers::{mmio32_register_map, Read};
+/// // The original register definition.
+/// mmio32_register_map![button: u8 { Read }];
+/// // A clone of the register.
+/// mmio32_register_map![button2: button];
+/// // An array of buttons:
+/// mmio32_register_map![button_array: [button; 8]];
+/// ```
+/// The data type and operations that a register has are inherited from the register it refers to
+/// (so `button2` implements `Read`, and `button_array` is an array of readable registers). These
+/// references work across crates (the register type being referred to is the path to the generated
+/// register module).
+///
+/// # Register blocks
+/// You can declare a block of registers:
+/// ```
+/// # fn main() {}
+/// use tock_registers::{mmio32_register_map, Read, Write};
+/// mmio32_register_map! {
+///     uart {
+///         0 => status: u8 { Read },
+///         1 => ctrl: u16 { Read, Write },
+///         3 => buffer: u8 { Read, Write },
+///     }
+/// }
+/// ```
+/// The leading integers (0, 1, 3) are address offsets (the value added to the base address to get
+/// the register's address). The generated module looks like:
+/// ```
+/// # fn main() {}
+/// # use tock_registers::{Mmio32, Read, Write};
+/// mod uart {
+///     use super::*;
+///     pub trait Interface: Copy {
+///         type status: tock_registers::Register<DataType = u8> + Read;
+///         fn status(self) -> Self::status;
+///         type ctrl: tock_registers::Register<DataType = u16> + Read + Write;
+///         fn ctrl(self) -> Self::ctrl;
+///         type buffer: tock_registers::Register<DataType = u8> + Read + Write;
+///         fn buffer(self) -> Self::buffer;
+///     }
+///     pub trait Bus {}
+///     impl Bus for Mmio32 {}
+///     #[derive(Clone, Copy)]
+///     pub struct Real<B: Bus>(B);
+/// }
+/// ```
+/// As before, `Real` implements `Interface`. The generated code includes tests that verify the
+/// offsets are correct (the registers must not overlap or have gaps between them).
+///
+/// # Register blocks with references
+/// The fields of register blocks can be arrays, references, and arrays of references:
+/// ```
+/// # fn main() {}
+/// use tock_registers::{mmio32_register_map, register_bitfields, Read, Write};
+/// register_bitfields! [u8,
+///     Control [OFF 0, INPUT 1, OUTPUT 2],
+/// ];
+/// mmio32_register_map! {
+///     gpio_pin {
+///         0 => control: Control::Register { Read, Write },
+///         1 => value: u8 { Read, Write },
+///     }
+/// }
+/// mmio32_register_map! {
+///     pinmux {
+///         0 => status: u8 { Read },
+///         // `pins` is an array of references to gpio_pin register blocks. This results in
+///         // gpio_pin::control and gpio_pin::value being interleaved for a total of 32 bytes.
+///         1 => pins: [gpio_pin; 16],
+///     }
+/// }
+/// ```
+///
+/// # Padding fields
+/// Sometimes, register blocks have gaps in them (usually for alignment). To handle this, you must
+/// insert a padding field where the gap is:
+/// ```
+/// # fn main() {}
+/// use tock_registers::{mmio32_register_map, Read, Write};
+/// mmio32_register_map! {
+///     uart {
+///         0 => status: u8 { Read },
+///         // Padding is specified by replacing the field definition with a _
+///         1 => _,
+///         // In this case, the padding is inferred to be 3 bytes, because the next field is at
+///         // offset 4.
+///         4 => ctrl: u16 { Read, Write },
+///         // You can also have padding with a specified size. This size is in bytes.
+///         6 => _: 1,
+///         7 => buffer: u8 { Read, Write },
+///     }
+/// }
+/// ```
+///
+/// # Aliased fields
+/// Sometimes, the offset tests are too restrictive. In that case, you can mark a register as
+/// `#[aliased]`, which removes it from the offset calculation logic entirely. This allows you to
+/// overlap registers:
+/// ```
+/// # fn main() {}
+/// use tock_registers::{mmio32_register_map, register_bitfields, Read, Write};
+/// register_bitfields! [u8,
+///     Control [OFF 0, ON 1],
+/// ];
+/// mmio32_register_map! {
+///     /// Uart with an unusual property: the "control" register and "status" register are located
+///     /// at the same offset. Writes go to the control register, while reads go to the status
+///     /// register.
+///     uart {
+///         0 => control: Control::Register { Write },
+///         #[aliased]
+///         0 => status: u8 { Read },
+///     }
+/// }
+/// ```
+/// One word of warning: the offset calculation logic also calculates the total size of a register
+/// block. That size is used when a register block is embedded into another register type (like
+/// another register block or array). Marking a register `#[aliased]` therefore makes it not affect
+/// the register's block size. If a `#[aliased]` register extends beyond the end of the
+/// non-`#[aliased]` registers, then that register will exist outside the register block's
+/// boundaries! That may or may not be what you wanted. If in doubt, put a padding field at the end
+/// to make sure the total size is correct.
+///
+/// # Visibility
+/// You can specify the visibility of the generated modules:
+/// ```
+/// # fn main() {}
+/// use tock_registers::{mmio32_register_map, Read};
+/// mmio32_register_map![pub button: u8 { Read }];     // pub mod button { ... }
+/// mmio32_register_map![pub(crate) button2: button];  // pub(crate) mod button2 { ... }
+/// mmio32_register_map![button_array: [button; 8]];   // mod button2 { ... }
+/// ```
+///
+/// # Specifying multiple buses
+/// There are some peripherals (such as LiteX peripherals) that support multiple bus types. For
+/// those peripherals, you can specify multiple buses. For example (using Mmio32 and Mmio64 because
+/// tock-registers does not provide the LiteX bus types):
+/// ```
+/// # fn main() {}
+/// use tock_registers::{register_map, Mmio32, Mmio64, Read, Write};
+/// register_map! {
+///     #[buses(Mmio32, Mmio64)]
+///     rng {
+///         0 => ctrl: u8 { Read, Write },
+///         1 => random_byte: u8 { Read },
+///     }
+/// }
+/// ```
+///
+/// Using `#[buses]` removes the default `Bus` type from the definition of the `Real` struct, so
+/// you will have to specify the bus any time you use `Real`.
+///
+/// Sometimes, such as for LiteX peripherals or peripherals that use `usize` registers, the offsets
+/// might depend on which bus is used. In that case, you can specify an array of offsets. The
+/// offsets apply to each bus in the order the buses are specified:
+/// ```
+/// # fn main() {}
+/// use tock_registers::{register_map, Mmio32, Mmio64, Read, Write};
+/// register_map! {
+///     #[buses(Mmio32, Mmio64)]
+///     dma_rng {
+///         0 => address: usize { Read, Write },
+///         [4, 8] => length: u32 { Read, Write },
+///         // Padding can also move around, and have per-bus length.
+///         [8, 12] => _: [4, 0],
+///         // Because of the previous padding, this is at offset 12 on both buses.
+///         12 => status: u8 { Read },
+///     }
+/// }
+/// ```
+///
+/// # Doc comments
+/// `register_map!` supports doc comments:
+/// ```
+/// # fn main() {}
+/// use tock_registers::{mmio32_register_map, Read, Write};
+/// mmio32_register_map! {
+///     /// This is an outer doc comment, which will be copied to the generated `uart` module.
+///     uart {
+///         /// This doc comment will be copied onto `Interface::status()`.
+///         0 => status: u8 { Read },
+///         /// This doc comment will be copied onto `Interface::buffer()`.
+///         1 => buffer: u8 { Read, Write },
+///     }
+/// }
+/// ```
+///
+/// # Multiple declarations
+///
+/// Instead of writing multiple `register_map!` invocations, you can instead put multiple
+/// definitions in a single `register_map!` call (comma-separated):
+///
+/// ```
+/// # fn main() {}
+/// use tock_registers::{register_map, Mmio32, Mmio64, Read, Write};
+/// register_map! {
+///     // This inner buses attribute sets the default buses for all declarations in this
+///     // register_map! call.
+///     #![buses(Mmio32, Mmio64)]
+///     //! Inner doc comments are copied onto every declaration.
+///     // Both `button` and `led` support both 32-bit and 64-bit MMIO.
+///     button: u8 { Read },
+///     /// You can still have outer doc comments per-declaration.
+///     led: u8 { Read, Write },
+///     // But `touch` only supports 32-bit MMIO.
+///     #[bus(Mmio32)]
+///     touch: u8 { Read },
+/// }
+/// ```
+///
+/// [`Read`]: trait@crate::Read
+/// [`Write`]: trait@crate::Write
+#[macro_export]
+macro_rules! register_map {
+    {$($arguments:tt)*} => {
+        $crate::internal::register_map!($crate $($arguments)*);
+    }
+}

--- a/src/mmio.rs
+++ b/src/mmio.rs
@@ -179,8 +179,7 @@ bus_impls!(Mmio64, Mmio64Nullable, [], usize, 8);
 bus_impls!(Mmio64, Mmio64Nullable, [T: Sized], *const T, 8);
 bus_impls!(Mmio64, Mmio64Nullable, [T: Sized], *mut T, 8);
 
-// TODO: Link using [`register_map!`](crate::register_map) when register_map! is merged.
-/// An alias for `register_map!` with `#![bus(Mmio32)]` at the top.
+/// An alias for [`register_map!`](crate::register_map) with `#![bus(Mmio32)]` at the top.
 /// In other words:
 /// ```
 /// use tock_registers::{mmio32_register_map, Mmio32};
@@ -189,8 +188,7 @@ bus_impls!(Mmio64, Mmio64Nullable, [T: Sized], *mut T, 8);
 /// }
 /// ```
 /// is equivalent to:
-// TODO: Remove `ignore` when register_map is merged.
-/// ```ignore
+/// ```
 /// use tock_registers::{register_map, Mmio32};
 /// register_map! {
 ///     #![bus(Mmio32)]
@@ -207,8 +205,7 @@ macro_rules! mmio32_register_map {
     }
 }
 
-// TODO: Link using [`register_map!`](crate::register_map) when register_map! is merged.
-/// An alias for `register_map!` with `#![bus(Mmio64)]` at the top.
+/// An alias for [`register_map!`](crate::register_map) with `#![bus(Mmio64)]` at the top.
 /// In other words:
 /// ```
 /// use tock_registers::{mmio64_register_map, Mmio64};
@@ -217,8 +214,7 @@ macro_rules! mmio32_register_map {
 /// }
 /// ```
 /// is equivalent to:
-// TODO: Remove `ignore` when register_map is merged.
-/// ```ignore
+/// ```
 /// use tock_registers::{register_map, Mmio64};
 /// register_map! {
 ///     #![bus(Mmio64)]


### PR DESCRIPTION
Most of this PR's contents are the documentation for `register_map!`. In addition to that, it un-ignores doc tests and adds rustdoc links that are possiblbe now.