### PR TITLE
Add the mmio test and generics example.

### DIFF
--- a/examples/generics.rs
+++ b/examples/generics.rs
@@ -1,0 +1,124 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+// Copyright Better Bytes 2026.
+
+//! Demonstrates register_map!'s support for generic buses and operations (and doubles as a test
+//! that register_map!'s generated code compiles in those cases).
+
+use std::fmt::Debug;
+use std::ptr::{read_volatile, NonNull};
+use tock_registers::{register_map, Address, Bus, BusRead, Read, RegisterArray, Span};
+
+// -----------------------------------------------------------------------------
+// Partial implementation of LiteX buses, to test register_map!'s support for
+// generic buses.
+// -----------------------------------------------------------------------------
+
+#[derive(Clone, Copy)]
+pub struct LiteX<const C: u8, const B: u8>(NonNull<()>);
+
+impl Address for LiteX<8, 32> {
+    unsafe fn byte_add(self, offset: usize) -> Self {
+        Self(unsafe { self.0.byte_add(offset) })
+    }
+}
+impl Address for LiteX<32, 32> {
+    unsafe fn byte_add(self, offset: usize) -> Self {
+        Self(unsafe { self.0.byte_add(offset) })
+    }
+}
+unsafe impl Bus<u8> for LiteX<8, 32> {
+    const PADDED_SIZE: usize = 4;
+}
+unsafe impl Bus<u8> for LiteX<32, 32> {
+    const PADDED_SIZE: usize = 4;
+}
+impl BusRead<u8> for LiteX<8, 32> {
+    unsafe fn read(self) -> u8 {
+        unsafe { read_volatile(self.0.as_ptr().cast_const().cast()) }
+    }
+}
+impl BusRead<u8> for LiteX<32, 32> {
+    unsafe fn read(self) -> u8 {
+        unsafe { read_volatile(self.0.as_ptr().cast_const().cast()) }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Defines the Dance operation, which is a generic operation.
+// -----------------------------------------------------------------------------
+
+pub trait Dance<Style> {
+    fn dance(self) -> Style;
+}
+
+#[macro_export]
+macro_rules! Dance {
+    (real_impl, $name:ident, $datatype:ty, <$style:path>, $($rest:tt)*) => {
+        impl<B: Bus> $crate::Dance<$style> for $name<B> {
+            fn dance(self) -> $style {
+                $style
+            }
+        }
+    };
+    ($($unknown:tt)*) => {};
+}
+
+#[derive(Debug)]
+pub struct Tango;
+#[derive(Debug)]
+pub struct Waltz;
+
+// -----------------------------------------------------------------------------
+// Defines the Ball operation, which has an associated type that the user can
+// constrain.
+// -----------------------------------------------------------------------------
+
+pub trait Ball {
+    type Use: Debug;
+    fn name(self) -> String;
+}
+
+#[macro_export]
+macro_rules! Ball {
+    (real_impl, $name:ident, $datatype:ty, <Use = $use:path>, $($rest:tt)*) => {
+        impl<B: Bus> $crate::Ball for $name<B> {
+            type Use = $use;
+            fn name(self) -> String {
+                format!("{:?}Ball", $use)
+            }
+        }
+    };
+    ($($unknown:tt)*) => {};
+}
+
+#[derive(Debug)]
+pub struct Basket;
+#[derive(Debug)]
+pub struct Disco;
+
+register_map![#[buses(LiteX<8, 32>, LiteX<32, 32>)] a: u8 { Read, Dance<Tango>, Dance<Waltz> }];
+register_map![#[buses(LiteX<8, 32>, LiteX<32, 32>)] b: [u8; 2] { Read, Ball<Use = Basket> }];
+register_map![#[buses(LiteX<8, 32>, LiteX<32, 32>)] c: a];
+register_map![#[buses(LiteX<8, 32>, LiteX<32, 32>)] d: [b; 2]];
+register_map! {
+    #[buses(LiteX<8, 32>, LiteX<32, 32>)]
+    e {
+        0 => f: u8 { Read, Dance<Tango> },
+        [4, 4] => g: [u8; 2] { Read, Ball<Use = Disco> },
+        12 => h: c,
+        16 => _: 8,
+        24 => i: [b; 2],
+    }
+}
+
+fn main() {
+    use e::Interface;
+    let mut peripheral = [0u8; e::Real::<LiteX<8, 32>>::SIZE];
+    let real = unsafe { e::Real::new(LiteX::<8, 32>(NonNull::from(&mut peripheral).cast())) };
+    println!("tango: {:?}", Dance::<Tango>::dance(real.f()));
+    println!("waltz: {:?}", Dance::<Waltz>::dance(real.h()));
+    println!("sport: {}", real.i().get(0).unwrap().get(0).unwrap().name());
+    println!("ceiling: {}", real.g().get(0).unwrap().name());
+}

--- a/tests/mmio.rs
+++ b/tests/mmio.rs
@@ -1,0 +1,265 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+// Copyright Better Bytes 2026.
+
+#![no_std]
+
+use core::{cell::UnsafeCell, ptr::NonNull};
+use tock_registers::{register_map, Mmio32, Mmio64, Read, RegisterArray, Write};
+use {inner_block::Interface as _, outer_block::Interface as _};
+
+register_map! {
+    #![buses(Mmio32, Mmio64)]
+    // External registers to reference.
+    a: u8 { Read, Write },
+    b: u16 { Read, Write },
+    inner_block {
+        0 => scalar_definition: usize { Read, Write },
+        [4, 8] => _: [4, 8],
+        [8, 16] => array_definition: [[u32; 2]; 3] { Read, Write },
+        [32, 40] => scalar_reference: a,
+        [33, 41] => _,
+        [36, 44] => array_reference: [[b; 2]; 3],
+    },
+    outer_block {
+        0 => scalar: u64 { Read, Write },
+        #[aliased]
+        1 => overlapped: u8 { Read, Write },
+        8 => nested: inner_block,
+        [56, 64] => nested_array: [inner_block; 2],
+        [152, 176] => flat_array: [u8; 2] { Read },
+        [154, 178] => flat_array_reference: [a; 2],
+    },
+}
+
+#[derive(PartialEq)]
+#[repr(C)]
+struct InnerBlock<Usize> {
+    scalar_definition: Usize,
+    _padding0: Usize,
+    array_definition: [[u32; 2]; 3],
+    scalar_reference: u8,
+    _padding1: [u8; 3],
+    array_reference: [[u16; 2]; 3],
+}
+
+#[derive(PartialEq)]
+#[repr(C)]
+struct OuterBlock<Usize> {
+    scalar: u64,
+    nested: InnerBlock<Usize>,
+    nested_array: [InnerBlock<Usize>; 2],
+    flat_array: [u8; 2],
+    flat_array_reference: [u8; 2],
+}
+
+#[test]
+fn mmio32() {
+    let peripheral = UnsafeCell::new(OuterBlock::<u32> {
+        scalar: 1,
+        nested: InnerBlock {
+            scalar_definition: 2,
+            _padding0: 0,
+            array_definition: [[3, 4], [5, 6], [7, 8]],
+            scalar_reference: 9,
+            _padding1: [0; 3],
+            array_reference: [[10, 11], [12, 13], [14, 15]],
+        },
+        nested_array: [
+            InnerBlock {
+                scalar_definition: 16,
+                _padding0: 0,
+                array_definition: [[17, 18], [19, 20], [21, 22]],
+                scalar_reference: 23,
+                _padding1: [0; 3],
+                array_reference: [[24, 25], [26, 27], [28, 29]],
+            },
+            InnerBlock {
+                scalar_definition: 30,
+                _padding0: 0,
+                array_definition: [[31, 32], [33, 34], [35, 36]],
+                scalar_reference: 37,
+                _padding1: [0; 3],
+                array_reference: [[38, 39], [40, 41], [42, 43]],
+            },
+        ],
+        flat_array: [44, 45],
+        flat_array_reference: [46, 47],
+    });
+    let mmio = Mmio32::new(NonNull::new(peripheral.get()).unwrap().cast());
+    let registers = unsafe { outer_block::Real::new(mmio) };
+    // Pointer offset validation: verifies that pointer offsets are correctly calculated through
+    // the various field types.
+    assert_eq!(registers.scalar().get(), 1);
+    assert_eq!(registers.overlapped().get(), 0);
+    #[cfg(any(target_pointer_width = "32", target_endian = "little"))]
+    assert_eq!(registers.nested().scalar_definition().get(), 2);
+    let array = registers.nested().array_definition();
+    assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 3);
+    assert_eq!(array.get(0).unwrap().get(1).unwrap().get(), 4);
+    assert_eq!(array.get(1).unwrap().get(0).unwrap().get(), 5);
+    assert_eq!(array.get(1).unwrap().get(1).unwrap().get(), 6);
+    assert_eq!(array.get(2).unwrap().get(0).unwrap().get(), 7);
+    assert_eq!(array.get(2).unwrap().get(1).unwrap().get(), 8);
+    assert_eq!(registers.nested().scalar_reference().get(), 9);
+    let array = registers.nested().array_reference();
+    assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 10);
+    assert_eq!(array.get(0).unwrap().get(1).unwrap().get(), 11);
+    assert_eq!(array.get(1).unwrap().get(0).unwrap().get(), 12);
+    assert_eq!(array.get(1).unwrap().get(1).unwrap().get(), 13);
+    assert_eq!(array.get(2).unwrap().get(0).unwrap().get(), 14);
+    assert_eq!(array.get(2).unwrap().get(1).unwrap().get(), 15);
+    let nested = registers.nested_array().get(0).unwrap();
+    #[cfg(any(target_pointer_width = "32", target_endian = "little"))]
+    assert_eq!(nested.scalar_definition().get(), 16);
+    let array = nested.array_definition();
+    assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 17);
+    assert_eq!(array.get(0).unwrap().get(1).unwrap().get(), 18);
+    assert_eq!(array.get(1).unwrap().get(0).unwrap().get(), 19);
+    assert_eq!(array.get(1).unwrap().get(1).unwrap().get(), 20);
+    assert_eq!(array.get(2).unwrap().get(0).unwrap().get(), 21);
+    assert_eq!(array.get(2).unwrap().get(1).unwrap().get(), 22);
+    assert_eq!(nested.scalar_reference().get(), 23);
+    let array = nested.array_reference();
+    assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 24);
+    assert_eq!(array.get(0).unwrap().get(1).unwrap().get(), 25);
+    assert_eq!(array.get(1).unwrap().get(0).unwrap().get(), 26);
+    assert_eq!(array.get(1).unwrap().get(1).unwrap().get(), 27);
+    assert_eq!(array.get(2).unwrap().get(0).unwrap().get(), 28);
+    assert_eq!(array.get(2).unwrap().get(1).unwrap().get(), 29);
+    let nested = registers.nested_array().get(1).unwrap();
+    #[cfg(any(target_pointer_width = "32", target_endian = "little"))]
+    assert_eq!(nested.scalar_definition().get(), 30);
+    let array = nested.array_definition();
+    assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 31);
+    assert_eq!(array.get(0).unwrap().get(1).unwrap().get(), 32);
+    assert_eq!(array.get(1).unwrap().get(0).unwrap().get(), 33);
+    assert_eq!(array.get(1).unwrap().get(1).unwrap().get(), 34);
+    assert_eq!(array.get(2).unwrap().get(0).unwrap().get(), 35);
+    assert_eq!(array.get(2).unwrap().get(1).unwrap().get(), 36);
+    assert_eq!(nested.scalar_reference().get(), 37);
+    let array = nested.array_reference();
+    assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 38);
+    assert_eq!(array.get(0).unwrap().get(1).unwrap().get(), 39);
+    assert_eq!(array.get(1).unwrap().get(0).unwrap().get(), 40);
+    assert_eq!(array.get(1).unwrap().get(1).unwrap().get(), 41);
+    assert_eq!(array.get(2).unwrap().get(0).unwrap().get(), 42);
+    assert_eq!(array.get(2).unwrap().get(1).unwrap().get(), 43);
+    assert_eq!(registers.flat_array().get(0).unwrap().get(), 44);
+    assert_eq!(registers.flat_array().get(1).unwrap().get(), 45);
+    assert_eq!(registers.flat_array_reference().get(0).unwrap().get(), 46);
+    assert_eq!(registers.flat_array_reference().get(1).unwrap().get(), 47);
+    // External write: verify Mmio can handle varying register values.
+    unsafe { (*peripheral.get()).scalar = 48 };
+    assert_eq!(registers.scalar().get(), 48);
+    // Perform a write.
+    registers.scalar().set(u64::MAX);
+    assert_eq!(unsafe { (*peripheral.get()).scalar }, u64::MAX);
+    assert_eq!(registers.overlapped().get(), 0xff);
+}
+
+#[test]
+fn mmio64() {
+    let peripheral = UnsafeCell::new(OuterBlock::<u64> {
+        scalar: 1,
+        nested: InnerBlock {
+            scalar_definition: 2,
+            _padding0: 0,
+            array_definition: [[3, 4], [5, 6], [7, 8]],
+            scalar_reference: 9,
+            _padding1: [0; 3],
+            array_reference: [[10, 11], [12, 13], [14, 15]],
+        },
+        nested_array: [
+            InnerBlock {
+                scalar_definition: 16,
+                _padding0: 0,
+                array_definition: [[17, 18], [19, 20], [21, 22]],
+                scalar_reference: 23,
+                _padding1: [0; 3],
+                array_reference: [[24, 25], [26, 27], [28, 29]],
+            },
+            InnerBlock {
+                scalar_definition: 30,
+                _padding0: 0,
+                array_definition: [[31, 32], [33, 34], [35, 36]],
+                scalar_reference: 37,
+                _padding1: [0; 3],
+                array_reference: [[38, 39], [40, 41], [42, 43]],
+            },
+        ],
+        flat_array: [44, 45],
+        flat_array_reference: [46, 47],
+    });
+    let mmio = Mmio64::new(NonNull::new(peripheral.get()).unwrap().cast());
+    let registers = unsafe { outer_block::Real::new(mmio) };
+    // Pointer offset validation: verifies that pointer offsets are correctly calculated through
+    // the various field types.
+    assert_eq!(registers.scalar().get(), 1);
+    assert_eq!(registers.overlapped().get(), 0);
+    #[cfg(any(target_pointer_width = "64", target_endian = "little"))]
+    assert_eq!(registers.nested().scalar_definition().get(), 2);
+    let array = registers.nested().array_definition();
+    assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 3);
+    assert_eq!(array.get(0).unwrap().get(1).unwrap().get(), 4);
+    assert_eq!(array.get(1).unwrap().get(0).unwrap().get(), 5);
+    assert_eq!(array.get(1).unwrap().get(1).unwrap().get(), 6);
+    assert_eq!(array.get(2).unwrap().get(0).unwrap().get(), 7);
+    assert_eq!(array.get(2).unwrap().get(1).unwrap().get(), 8);
+    assert_eq!(registers.nested().scalar_reference().get(), 9);
+    let array = registers.nested().array_reference();
+    assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 10);
+    assert_eq!(array.get(0).unwrap().get(1).unwrap().get(), 11);
+    assert_eq!(array.get(1).unwrap().get(0).unwrap().get(), 12);
+    assert_eq!(array.get(1).unwrap().get(1).unwrap().get(), 13);
+    assert_eq!(array.get(2).unwrap().get(0).unwrap().get(), 14);
+    assert_eq!(array.get(2).unwrap().get(1).unwrap().get(), 15);
+    let nested = registers.nested_array().get(0).unwrap();
+    #[cfg(any(target_pointer_width = "64", target_endian = "little"))]
+    assert_eq!(nested.scalar_definition().get(), 16);
+    let array = nested.array_definition();
+    assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 17);
+    assert_eq!(array.get(0).unwrap().get(1).unwrap().get(), 18);
+    assert_eq!(array.get(1).unwrap().get(0).unwrap().get(), 19);
+    assert_eq!(array.get(1).unwrap().get(1).unwrap().get(), 20);
+    assert_eq!(array.get(2).unwrap().get(0).unwrap().get(), 21);
+    assert_eq!(array.get(2).unwrap().get(1).unwrap().get(), 22);
+    assert_eq!(nested.scalar_reference().get(), 23);
+    let array = nested.array_reference();
+    assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 24);
+    assert_eq!(array.get(0).unwrap().get(1).unwrap().get(), 25);
+    assert_eq!(array.get(1).unwrap().get(0).unwrap().get(), 26);
+    assert_eq!(array.get(1).unwrap().get(1).unwrap().get(), 27);
+    assert_eq!(array.get(2).unwrap().get(0).unwrap().get(), 28);
+    assert_eq!(array.get(2).unwrap().get(1).unwrap().get(), 29);
+    let nested = registers.nested_array().get(1).unwrap();
+    #[cfg(any(target_pointer_width = "64", target_endian = "little"))]
+    assert_eq!(nested.scalar_definition().get(), 30);
+    let array = nested.array_definition();
+    assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 31);
+    assert_eq!(array.get(0).unwrap().get(1).unwrap().get(), 32);
+    assert_eq!(array.get(1).unwrap().get(0).unwrap().get(), 33);
+    assert_eq!(array.get(1).unwrap().get(1).unwrap().get(), 34);
+    assert_eq!(array.get(2).unwrap().get(0).unwrap().get(), 35);
+    assert_eq!(array.get(2).unwrap().get(1).unwrap().get(), 36);
+    assert_eq!(nested.scalar_reference().get(), 37);
+    let array = nested.array_reference();
+    assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 38);
+    assert_eq!(array.get(0).unwrap().get(1).unwrap().get(), 39);
+    assert_eq!(array.get(1).unwrap().get(0).unwrap().get(), 40);
+    assert_eq!(array.get(1).unwrap().get(1).unwrap().get(), 41);
+    assert_eq!(array.get(2).unwrap().get(0).unwrap().get(), 42);
+    assert_eq!(array.get(2).unwrap().get(1).unwrap().get(), 43);
+    assert_eq!(registers.flat_array().get(0).unwrap().get(), 44);
+    assert_eq!(registers.flat_array().get(1).unwrap().get(), 45);
+    assert_eq!(registers.flat_array_reference().get(0).unwrap().get(), 46);
+    assert_eq!(registers.flat_array_reference().get(1).unwrap().get(), 47);
+    // External write: verify Mmio can handle varying register values.
+    unsafe { (*peripheral.get()).scalar = 48 };
+    assert_eq!(registers.scalar().get(), 48);
+    // Perform a write.
+    registers.scalar().set(u64::MAX);
+    assert_eq!(unsafe { (*peripheral.get()).scalar }, u64::MAX);
+    assert_eq!(registers.overlapped().get(), 0xff);
+}


### PR DESCRIPTION
The mmio test verifies the `Mmio32` and `Mmio64` buses work correctly (which also verifies that offsets are calculated correctly). It is designed to be run in Miri.

The generics example verifies that buses and operations can be generic (and operations can be generic traits or have associated generic types).