### PR TITLE
Limit many Mmio32/Mmio64 methods and traits to 32-bit and 64-bit systems.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,8 @@ expand_macros_test: toolchain
 .PHONY: miri_test
 miri_test:
 	cd nightly && RUSTFLAGS="-D warnings" \
-		cargo miri test --all-targets --manifest-path=../Cargo.toml --workspace
+		cargo miri test --all-targets --manifest-path=../Cargo.toml \
+			--target=x86_64-unknown-linux-gnu --workspace
+	cd nightly && RUSTFLAGS="-D warnings" \
+		cargo miri test --manifest-path=../Cargo.toml \
+			--target=i686-unknown-linux-gnu --test mmio

--- a/examples/rng.rs
+++ b/examples/rng.rs
@@ -7,7 +7,7 @@
 ///
 /// This is designed to demonstrate how unit testing hooks integrate with
 /// typical hardware instantiation.
-use tock_registers::{mmio32_register_map, Mmio32, Read};
+use tock_registers::{mmio32_register_map, Read};
 
 // This defines the peripheral interface. This interface definition is
 // independent of underlying implementation (i.e., real hardware or a mock).
@@ -28,7 +28,10 @@ mmio32_register_map! {
 ///
 /// None of this code is exercised when running tests, rather, it's included
 /// as a reference for a minimal complete example.
+#[cfg(target_pointer_width = "32")]
 pub fn create_and_use_rng<R: rng::Interface>() {
+    use tock_registers::Mmio32;
+
     // MMIO address of the hardware peripheral (e.g., from a datasheet).
     const RNG_HARDWARE_ADDRESS: usize = 0x100;
 
@@ -48,7 +51,7 @@ pub fn create_and_use_rng<R: rng::Interface>() {
 }
 
 /// Instance of an RNG (may be backed by hardware or mocks).
-struct Rng<R: rng::Interface> {
+pub struct Rng<R: rng::Interface> {
     registers: R,
 }
 

--- a/nightly/rust-toolchain.toml
+++ b/nightly/rust-toolchain.toml
@@ -6,3 +6,4 @@
 [toolchain]
 channel = "nightly-2026-01-27"
 components = ["miri", "rust-src"]
+targets = ["i686-unknown-linux-gnu", "x86_64-unknown-linux-gnu"]

--- a/src/mmio.rs
+++ b/src/mmio.rs
@@ -8,7 +8,7 @@ use core::ptr::{read_volatile, write_volatile, NonNull};
 
 /// Macro to declare the Mmio* structs and provide a few impls for each.
 macro_rules! mmio_structs {
-    [$($(#[$docs:meta])* $name:ident($storage:ty))*] => {$(
+    [$($(#[$docs:meta])* $name:ident($storage:ty)[$width:literal])*] => {$(
         $(#[$docs])*
         ///
         /// **Note: These cannot be used to start or stop DMA operations.** This bus implements the
@@ -23,6 +23,7 @@ macro_rules! mmio_structs {
 
         impl $name {
             /// Returns a new MMIO address containing the given pointer.
+            #[cfg(target_pointer_width = $width)]
             pub const fn new(ptr: $storage) -> Self {
                 Self(ptr)
             }
@@ -48,21 +49,21 @@ macro_rules! mmio_structs {
 
 mmio_structs! {
     /// MMIO register bus for 32-bit systems.
-    Mmio32(NonNull<()>)
+    Mmio32(NonNull<()>)["32"]
 
     /// MMIO register bus for 64-bit systems.
-    Mmio64(NonNull<()>)
+    Mmio64(NonNull<()>)["64"]
 
     /// MMIO register bus for 32-bit systems that can point to a register at the 0 address.
-    Mmio32Nullable(*mut ())
+    Mmio32Nullable(*mut ())["32"]
 
     /// MMIO register bus for 64-bit systems that can point to a register at the 0 address.
-    Mmio64Nullable(*mut ())
+    Mmio64Nullable(*mut ())["64"]
 }
 
 /// Macro to provide the from_addr functions for the non-nullable Mmio* structs.
 macro_rules! from_addr_nonnull {
-    [$($name:ident)*] => {$(impl $name {
+    [$($name:ident[$width:literal])*] => {$(impl $name {
         /// Constructs a new MMIO register bus pointing to the given address. If you have an
         /// address from a datasheet and want to access it as a register struct, this is probably
         /// the method you want.
@@ -76,6 +77,7 @@ macro_rules! from_addr_nonnull {
         /// Panics if the provided address is null, and panics during const evaluation if the
         /// pointer cannot be determined to be null or not. If you want to access a register at
         /// address 0, use one of the nullable MMIO structs.
+        #[cfg(target_pointer_width = $width)]
         #[track_caller]
         pub const fn from_addr(addr: usize) -> Self {
             // TODO: Once the MSRV reaches:
@@ -93,11 +95,11 @@ macro_rules! from_addr_nonnull {
     })*}
 }
 
-from_addr_nonnull![Mmio32 Mmio64];
+from_addr_nonnull![Mmio32["32"] Mmio64["64"]];
 
 /// Macro to provide the from_addr functions for the Mmio*Nullable structs.
 macro_rules! from_addr_nullable {
-    [$($name:ident)*] => {$(impl $name {
+    [$($name:ident[$width:literal])*] => {$(impl $name {
         /// Constructs a new MMIO register bus pointing to the given address. If you have an
         /// address from a datasheet and want to access it as a register struct, this is probably
         /// the method you want.
@@ -106,6 +108,7 @@ macro_rules! from_addr_nullable {
         /// memory, but it means it cannot be used to access Rust memory. If you want to access
         /// Rust memory (i.e. if this is pointing somewhere other than MMIO memory) then you must
         /// use [`new`](Self::new) to construct this bus instead.
+        #[cfg(target_pointer_width = $width)]
         pub const fn from_addr(addr: usize) -> Self {
             // TODO: Once the MSRV reaches 1.84, replace this cast with
             // core::ptr::without_provenance_mut.
@@ -114,11 +117,11 @@ macro_rules! from_addr_nullable {
     })*}
 }
 
-from_addr_nullable![Mmio32Nullable Mmio64Nullable];
+from_addr_nullable![Mmio32Nullable["32"] Mmio64Nullable["64"]];
 
 /// Macro to implement the Bus traits for the Mmio* structs.
 macro_rules! bus_impls {
-    [$nonnull:ident, $nullable:ident, [$($generics:tt)*], $value:ty, $size:literal] => {
+    [$nonnull:ident, $nullable:ident, $width:literal, [$($generics:tt)*], $value:ty, $size:literal] => {
         /// Safety: All the bus_impls! invocations have the correct size.
         unsafe impl<$($generics)*> Bus<$value> for $nonnull {
             const PADDED_SIZE: usize = $size;
@@ -127,6 +130,7 @@ macro_rules! bus_impls {
         unsafe impl<$($generics)*> Bus<$value> for $nullable {
             const PADDED_SIZE: usize = $size;
         }
+        #[cfg(target_pointer_width = $width)]
         impl<$($generics)*> BusRead<$value> for $nonnull {
             unsafe fn read(self) -> $value {
                 // BusRead::read's preconditions guarantee that a readable register with value type
@@ -135,6 +139,7 @@ macro_rules! bus_impls {
                 unsafe { self.0.cast().read_volatile() }
             }
         }
+        #[cfg(target_pointer_width = $width)]
         impl<$($generics)*> BusRead<$value> for $nullable {
             unsafe fn read(self) -> $value {
                 // BusRead::read's preconditions guarantee that a readable register with value type
@@ -143,6 +148,7 @@ macro_rules! bus_impls {
                 unsafe { read_volatile(self.0.cast_const().cast()) }
             }
         }
+        #[cfg(target_pointer_width = $width)]
         impl<$($generics)*> BusWrite<$value> for $nonnull {
             unsafe fn write(self, value: $value) {
                 // BusRead::write's preconditions guarantee that a writable register with value
@@ -152,6 +158,7 @@ macro_rules! bus_impls {
                 unsafe { self.0.cast().write_volatile(value) }
             }
         }
+        #[cfg(target_pointer_width = $width)]
         impl<$($generics)*> BusWrite<$value> for $nullable {
             unsafe fn write(self, value: $value) {
                 // BusRead::write's preconditions guarantee that a writable register with value
@@ -163,21 +170,21 @@ macro_rules! bus_impls {
     }
 }
 
-bus_impls!(Mmio32, Mmio32Nullable, [], u8, 1);
-bus_impls!(Mmio32, Mmio32Nullable, [], u16, 2);
-bus_impls!(Mmio32, Mmio32Nullable, [], u32, 4);
-bus_impls!(Mmio32, Mmio32Nullable, [], u64, 8);
-bus_impls!(Mmio32, Mmio32Nullable, [], usize, 4);
-bus_impls!(Mmio32, Mmio32Nullable, [T: Sized], *const T, 4);
-bus_impls!(Mmio32, Mmio32Nullable, [T: Sized], *mut T, 4);
-bus_impls!(Mmio64, Mmio64Nullable, [], u8, 1);
-bus_impls!(Mmio64, Mmio64Nullable, [], u16, 2);
-bus_impls!(Mmio64, Mmio64Nullable, [], u32, 4);
-bus_impls!(Mmio64, Mmio64Nullable, [], u64, 8);
-bus_impls!(Mmio64, Mmio64Nullable, [], u128, 16);
-bus_impls!(Mmio64, Mmio64Nullable, [], usize, 8);
-bus_impls!(Mmio64, Mmio64Nullable, [T: Sized], *const T, 8);
-bus_impls!(Mmio64, Mmio64Nullable, [T: Sized], *mut T, 8);
+bus_impls!(Mmio32, Mmio32Nullable, "32", [], u8, 1);
+bus_impls!(Mmio32, Mmio32Nullable, "32", [], u16, 2);
+bus_impls!(Mmio32, Mmio32Nullable, "32", [], u32, 4);
+bus_impls!(Mmio32, Mmio32Nullable, "32", [], u64, 8);
+bus_impls!(Mmio32, Mmio32Nullable, "32", [], usize, 4);
+bus_impls!(Mmio32, Mmio32Nullable, "32", [T: Sized], *const T, 4);
+bus_impls!(Mmio32, Mmio32Nullable, "32", [T: Sized], *mut T, 4);
+bus_impls!(Mmio64, Mmio64Nullable, "64", [], u8, 1);
+bus_impls!(Mmio64, Mmio64Nullable, "64", [], u16, 2);
+bus_impls!(Mmio64, Mmio64Nullable, "64", [], u32, 4);
+bus_impls!(Mmio64, Mmio64Nullable, "64", [], u64, 8);
+bus_impls!(Mmio64, Mmio64Nullable, "64", [], u128, 16);
+bus_impls!(Mmio64, Mmio64Nullable, "64", [], usize, 8);
+bus_impls!(Mmio64, Mmio64Nullable, "64", [T: Sized], *const T, 8);
+bus_impls!(Mmio64, Mmio64Nullable, "64", [T: Sized], *mut T, 8);
 
 /// An alias for [`register_map!`](crate::register_map) with `#![bus(Mmio32)]` at the top.
 /// In other words:

--- a/tests/mmio.rs
+++ b/tests/mmio.rs
@@ -3,6 +3,10 @@
 // Copyright Tock Contributors 2026.
 // Copyright Better Bytes 2026.
 
+//! This tests verifies that the Mmio32 and Mmio64 buses work correctly. Indirectly, it also
+//! verifies that register offsets are calculated correctly. It is designed to run in Miri on
+//! 32-bit and 64-bit targets.
+
 #![no_std]
 
 use core::{cell::UnsafeCell, ptr::NonNull};
@@ -33,9 +37,14 @@ register_map! {
     },
 }
 
+#[cfg(target_pointer_width = "32")]
+type Usize = u32;
+#[cfg(target_pointer_width = "64")]
+type Usize = u64;
+
 #[derive(PartialEq)]
 #[repr(C)]
-struct InnerBlock<Usize> {
+struct InnerBlock {
     scalar_definition: Usize,
     _padding0: Usize,
     array_definition: [[u32; 2]; 3],
@@ -46,122 +55,22 @@ struct InnerBlock<Usize> {
 
 #[derive(PartialEq)]
 #[repr(C)]
-struct OuterBlock<Usize> {
+struct OuterBlock {
     scalar: u64,
-    nested: InnerBlock<Usize>,
-    nested_array: [InnerBlock<Usize>; 2],
+    nested: InnerBlock,
+    nested_array: [InnerBlock; 2],
     flat_array: [u8; 2],
     flat_array_reference: [u8; 2],
 }
 
 #[test]
-fn mmio32() {
-    let peripheral = UnsafeCell::new(OuterBlock::<u32> {
-        scalar: 1,
-        nested: InnerBlock {
-            scalar_definition: 2,
-            _padding0: 0,
-            array_definition: [[3, 4], [5, 6], [7, 8]],
-            scalar_reference: 9,
-            _padding1: [0; 3],
-            array_reference: [[10, 11], [12, 13], [14, 15]],
-        },
-        nested_array: [
-            InnerBlock {
-                scalar_definition: 16,
-                _padding0: 0,
-                array_definition: [[17, 18], [19, 20], [21, 22]],
-                scalar_reference: 23,
-                _padding1: [0; 3],
-                array_reference: [[24, 25], [26, 27], [28, 29]],
-            },
-            InnerBlock {
-                scalar_definition: 30,
-                _padding0: 0,
-                array_definition: [[31, 32], [33, 34], [35, 36]],
-                scalar_reference: 37,
-                _padding1: [0; 3],
-                array_reference: [[38, 39], [40, 41], [42, 43]],
-            },
-        ],
-        flat_array: [44, 45],
-        flat_array_reference: [46, 47],
-    });
-    let mmio = Mmio32::new(NonNull::new(peripheral.get()).unwrap().cast());
-    let registers = unsafe { outer_block::Real::new(mmio) };
-    // Pointer offset validation: verifies that pointer offsets are correctly calculated through
-    // the various field types.
-    assert_eq!(registers.scalar().get(), 1);
-    assert_eq!(registers.overlapped().get(), 0);
-    #[cfg(any(target_pointer_width = "32", target_endian = "little"))]
-    assert_eq!(registers.nested().scalar_definition().get(), 2);
-    let array = registers.nested().array_definition();
-    assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 3);
-    assert_eq!(array.get(0).unwrap().get(1).unwrap().get(), 4);
-    assert_eq!(array.get(1).unwrap().get(0).unwrap().get(), 5);
-    assert_eq!(array.get(1).unwrap().get(1).unwrap().get(), 6);
-    assert_eq!(array.get(2).unwrap().get(0).unwrap().get(), 7);
-    assert_eq!(array.get(2).unwrap().get(1).unwrap().get(), 8);
-    assert_eq!(registers.nested().scalar_reference().get(), 9);
-    let array = registers.nested().array_reference();
-    assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 10);
-    assert_eq!(array.get(0).unwrap().get(1).unwrap().get(), 11);
-    assert_eq!(array.get(1).unwrap().get(0).unwrap().get(), 12);
-    assert_eq!(array.get(1).unwrap().get(1).unwrap().get(), 13);
-    assert_eq!(array.get(2).unwrap().get(0).unwrap().get(), 14);
-    assert_eq!(array.get(2).unwrap().get(1).unwrap().get(), 15);
-    let nested = registers.nested_array().get(0).unwrap();
-    #[cfg(any(target_pointer_width = "32", target_endian = "little"))]
-    assert_eq!(nested.scalar_definition().get(), 16);
-    let array = nested.array_definition();
-    assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 17);
-    assert_eq!(array.get(0).unwrap().get(1).unwrap().get(), 18);
-    assert_eq!(array.get(1).unwrap().get(0).unwrap().get(), 19);
-    assert_eq!(array.get(1).unwrap().get(1).unwrap().get(), 20);
-    assert_eq!(array.get(2).unwrap().get(0).unwrap().get(), 21);
-    assert_eq!(array.get(2).unwrap().get(1).unwrap().get(), 22);
-    assert_eq!(nested.scalar_reference().get(), 23);
-    let array = nested.array_reference();
-    assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 24);
-    assert_eq!(array.get(0).unwrap().get(1).unwrap().get(), 25);
-    assert_eq!(array.get(1).unwrap().get(0).unwrap().get(), 26);
-    assert_eq!(array.get(1).unwrap().get(1).unwrap().get(), 27);
-    assert_eq!(array.get(2).unwrap().get(0).unwrap().get(), 28);
-    assert_eq!(array.get(2).unwrap().get(1).unwrap().get(), 29);
-    let nested = registers.nested_array().get(1).unwrap();
-    #[cfg(any(target_pointer_width = "32", target_endian = "little"))]
-    assert_eq!(nested.scalar_definition().get(), 30);
-    let array = nested.array_definition();
-    assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 31);
-    assert_eq!(array.get(0).unwrap().get(1).unwrap().get(), 32);
-    assert_eq!(array.get(1).unwrap().get(0).unwrap().get(), 33);
-    assert_eq!(array.get(1).unwrap().get(1).unwrap().get(), 34);
-    assert_eq!(array.get(2).unwrap().get(0).unwrap().get(), 35);
-    assert_eq!(array.get(2).unwrap().get(1).unwrap().get(), 36);
-    assert_eq!(nested.scalar_reference().get(), 37);
-    let array = nested.array_reference();
-    assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 38);
-    assert_eq!(array.get(0).unwrap().get(1).unwrap().get(), 39);
-    assert_eq!(array.get(1).unwrap().get(0).unwrap().get(), 40);
-    assert_eq!(array.get(1).unwrap().get(1).unwrap().get(), 41);
-    assert_eq!(array.get(2).unwrap().get(0).unwrap().get(), 42);
-    assert_eq!(array.get(2).unwrap().get(1).unwrap().get(), 43);
-    assert_eq!(registers.flat_array().get(0).unwrap().get(), 44);
-    assert_eq!(registers.flat_array().get(1).unwrap().get(), 45);
-    assert_eq!(registers.flat_array_reference().get(0).unwrap().get(), 46);
-    assert_eq!(registers.flat_array_reference().get(1).unwrap().get(), 47);
-    // External write: verify Mmio can handle varying register values.
-    unsafe { (*peripheral.get()).scalar = 48 };
-    assert_eq!(registers.scalar().get(), 48);
-    // Perform a write.
-    registers.scalar().set(u64::MAX);
-    assert_eq!(unsafe { (*peripheral.get()).scalar }, u64::MAX);
-    assert_eq!(registers.overlapped().get(), 0xff);
-}
+fn mmio() {
+    #[cfg(target_pointer_width = "32")]
+    type Mmio = Mmio32;
+    #[cfg(target_pointer_width = "64")]
+    type Mmio = Mmio64;
 
-#[test]
-fn mmio64() {
-    let peripheral = UnsafeCell::new(OuterBlock::<u64> {
+    let peripheral = UnsafeCell::new(OuterBlock {
         scalar: 1,
         nested: InnerBlock {
             scalar_definition: 2,
@@ -192,13 +101,12 @@ fn mmio64() {
         flat_array: [44, 45],
         flat_array_reference: [46, 47],
     });
-    let mmio = Mmio64::new(NonNull::new(peripheral.get()).unwrap().cast());
+    let mmio = Mmio::new(NonNull::new(peripheral.get()).unwrap().cast());
     let registers = unsafe { outer_block::Real::new(mmio) };
     // Pointer offset validation: verifies that pointer offsets are correctly calculated through
     // the various field types.
     assert_eq!(registers.scalar().get(), 1);
     assert_eq!(registers.overlapped().get(), 0);
-    #[cfg(any(target_pointer_width = "64", target_endian = "little"))]
     assert_eq!(registers.nested().scalar_definition().get(), 2);
     let array = registers.nested().array_definition();
     assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 3);
@@ -216,7 +124,6 @@ fn mmio64() {
     assert_eq!(array.get(2).unwrap().get(0).unwrap().get(), 14);
     assert_eq!(array.get(2).unwrap().get(1).unwrap().get(), 15);
     let nested = registers.nested_array().get(0).unwrap();
-    #[cfg(any(target_pointer_width = "64", target_endian = "little"))]
     assert_eq!(nested.scalar_definition().get(), 16);
     let array = nested.array_definition();
     assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 17);
@@ -234,7 +141,6 @@ fn mmio64() {
     assert_eq!(array.get(2).unwrap().get(0).unwrap().get(), 28);
     assert_eq!(array.get(2).unwrap().get(1).unwrap().get(), 29);
     let nested = registers.nested_array().get(1).unwrap();
-    #[cfg(any(target_pointer_width = "64", target_endian = "little"))]
     assert_eq!(nested.scalar_definition().get(), 30);
     let array = nested.array_definition();
     assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 31);


### PR DESCRIPTION
Mmio32 and Mmio64 must exist and implement Bus on every architecture so that `register_map!` can be used in a unit test environment. However, implementing BusRead/BusWrite on other targets is unnecessary and semantically incorrect. Also, they don't need to be constructible in unit test environments. This `cfg`-gates those methods and trait implementations to targets with the correct bus width.

`tests/mmio.rs` has been adjusted so that it no longer tries to emulate a target system of a different architecture. Instead, I use Miri to emulate 32-bit and 64-bit target systems.