### PR TITLE
codegen: document `lens` module

### DIFF
--- a/codegen/src/block.rs
+++ b/codegen/src/block.rs
@@ -38,6 +38,7 @@ pub fn generate(env: Env, tock_registers: &Path, layout: &Layout, fields: &[Fiel
     let name = &layout.name;
     let interface_comment = interface_doc_comment();
     let mut interface_fields = TokenStream::new();
+    let lens_comment = lens_doc_comment();
     let mut len_definitions = TokenStream::new();
     let bus_comment = bus_doc_comment();
     let mut bus_bounds = TokenStream::new();
@@ -202,7 +203,7 @@ pub fn generate(env: Env, tock_registers: &Path, layout: &Layout, fields: &[Fiel
             #interface_comment pub trait Interface: #tock_registers::internal::core::marker::Copy {
                 #interface_fields
             }
-            pub mod lens { #len_definitions }
+            #lens_comment pub mod lens { #len_definitions }
             #bus_comment #[allow(clippy::trait_duplication_in_bounds)]
             pub trait Bus: #tock_registers::Address #bus_bounds + sealed::Bus {
                 const SIZE: usize;
@@ -254,6 +255,19 @@ pub fn interface_doc_comment() -> TokenStream {
     quote! {
         /// Trait representing this register block. Driver code can use this trait to work with
         /// both real hardware and fake implementations of the peripheral (for unit testing).
+    }
+}
+
+pub fn lens_doc_comment() -> TokenStream {
+    quote! {
+        /// Phantom types encoding the lengths of register arrays in this block.
+        ///
+        /// Driver code can use these as type parameters when writing generic functions
+        /// over register arrays in this block, for example:
+        ///
+        /// ```ignore
+        /// fn process<R: RegisterArray<my_block::lens::my_array>>(regs: R) { ... }
+        /// ```
     }
 }
 

--- a/codegen/src/block_test_all_fields.rs
+++ b/codegen/src/block_test_all_fields.rs
@@ -4,7 +4,8 @@
 // Copyright Better Bytes 2026.
 
 use crate::block::{
-    bus_doc_comment, field_struct_doc_comment, interface_doc_comment, real_doc_comment,
+    bus_doc_comment, field_struct_doc_comment, interface_doc_comment, lens_doc_comment,
+    real_doc_comment,
 };
 use crate::{new_doc_comment, register_map, test_util::assert_tokens_eq, Env::ProcMacro};
 use quote::quote;
@@ -28,6 +29,7 @@ fn all_field_types_example() {
         }
     };
     let interface_comment = interface_doc_comment();
+    let lens_comment = lens_doc_comment();
     let bus_comment = bus_doc_comment();
     let real_comment = real_doc_comment();
     let new_comment = new_doc_comment();
@@ -62,7 +64,7 @@ fn all_field_types_example() {
                     lens::flat_array_reference, Element: c::Interface>;
                 fn flat_array_reference(self) -> Self::flat_array_reference;
             }
-            pub mod lens {
+            #lens_comment pub mod lens {
                 pub enum array_definition<const N: usize> {}
                 impl ::tock_registers::array::Len for array_definition<0usize> { const LEN: usize = 2; }
                 impl ::tock_registers::array::Len for array_definition<1usize> { const LEN: usize = 3; }

--- a/codegen/src/block_test_docs.rs
+++ b/codegen/src/block_test_docs.rs
@@ -72,6 +72,14 @@ fn doc_comments() {
                 /// Doc comment N
                 fn array_reference(self) -> Self::array_reference;
             }
+            /// Phantom types encoding the lengths of register arrays in this block.
+            ///
+            /// Driver code can use these as type parameters when writing generic functions
+            /// over register arrays in this block, for example:
+            ///
+            /// ```ignore
+            /// fn process<R: RegisterArray<my_block::lens::my_array>>(regs: R) { ... }
+            /// ```
             pub mod lens {
                 pub enum array_definition<const N: usize> {}
                 impl ::tock_registers::array::Len for

--- a/codegen/src/block_test_empty.rs
+++ b/codegen/src/block_test_empty.rs
@@ -3,7 +3,7 @@
 // Copyright Tock Contributors 2026.
 // Copyright Better Bytes 2026.
 
-use crate::block::{bus_doc_comment, interface_doc_comment, real_doc_comment};
+use crate::block::{bus_doc_comment, interface_doc_comment, lens_doc_comment, real_doc_comment};
 use crate::{new_doc_comment, register_map, test_util::assert_tokens_eq, Env::External};
 use quote::quote;
 
@@ -16,6 +16,7 @@ fn empty() {
         pub foo {}
     };
     let interface_comment = interface_doc_comment();
+    let lens_comment = lens_doc_comment();
     let bus_comment = bus_doc_comment();
     let real_comment = real_doc_comment();
     let new_comment = new_doc_comment();
@@ -24,7 +25,7 @@ fn empty() {
             #![allow(non_camel_case_types,dead_code,non_upper_case_globals)] use super::*;
             #interface_comment
             pub trait Interface: ::tock_registers::internal::core::marker::Copy {}
-            pub mod lens {}
+            #lens_comment pub mod lens {}
             #bus_comment #[allow(clippy::trait_duplication_in_bounds)]
             pub trait Bus: ::tock_registers::Address + sealed::Bus {
                 const SIZE: usize;

--- a/codegen/src/block_test_offsets.rs
+++ b/codegen/src/block_test_offsets.rs
@@ -4,7 +4,8 @@
 // Copyright Better Bytes 2026.
 
 use crate::block::{
-    bus_doc_comment, field_struct_doc_comment, interface_doc_comment, real_doc_comment,
+    bus_doc_comment, field_struct_doc_comment, interface_doc_comment, lens_doc_comment,
+    real_doc_comment,
 };
 use crate::{new_doc_comment, register_map, test_util::assert_tokens_eq, Env::ProcMacro};
 use quote::quote;
@@ -32,6 +33,7 @@ fn offsets() {
         }
     };
     let interface_comment = interface_doc_comment();
+    let lens_comment = lens_doc_comment();
     let bus_comment = bus_doc_comment();
     let real_comment = real_doc_comment();
     let new_comment = new_doc_comment();
@@ -56,7 +58,7 @@ fn offsets() {
                 type padded_pos: ::tock_registers::Register<DataType = u8> + Read;
                 fn padded_pos(self) -> Self::padded_pos;
             }
-            pub mod lens {}
+            #lens_comment pub mod lens {}
             #bus_comment #[allow(clippy::trait_duplication_in_bounds)]
             pub trait Bus: ::tock_registers::Address + ::tock_registers::DataTypeBus<usize> +
                 ::tock_registers::DataTypeBus<u32> + ::tock_registers::DataTypeBus<u16> +


### PR DESCRIPTION
This is mostly just a cosmetic thing, but I was working through my understanding of things here again, noticed that there wasn't any doc comments on the `lens` module, but then decided that was appropriate.

With that in mind, I think we should put the hidden-docs cue in the implementation here that it's an internal thing.

AI Disclosure: Claude wrote the actual commit.