### PR TITLE
Add `unsafe` to register map definitions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ use tock_registers::{mmio32_register_map, Mmio32, Read, Write};
 // addresses.
 mmio32_register_map! {
     /// Documentation for `peripheral`.
-    peripheral {
+    ///
+    /// # Safety: This matches peripheral X; datasheet: <URL>.
+    unsafe peripheral {
         // Control register: read-write. `Control` is defined using the
         // `register_bitfields!` macro.
         0x000 => cr: Control::Register { Read, Write },
@@ -52,8 +54,9 @@ mmio32_register_map! {
 }
 ```
 
-The fields (registers and padding) must be in order of increasing offset with no
-gaps.
+Declaring a register map is `unsafe` because it is important (for memory safety)
+that the register map be correct for the hardware. The fields (registers and
+padding) must be in order of increasing offset with no gaps.
 
 The macro generates a module that is designed to be used both on real hardware
 and in a unit test environment. Therefore, the module contains traits and a
@@ -101,7 +104,7 @@ the `pub` keyword just before the module name:
 use tock_registers::{mmio32_register_map, Read};
 
 mmio32_register_map! {
-    pub peripheral {
+    pub unsafe peripheral {
         0 => status: u8 { Read },
     }
 }
@@ -467,7 +470,7 @@ description of the naming convention for each:
 use tock_registers::{mmio32_register_map, register_bitfields, Read, Write};
 
 mmio32_register_map! {
-    registers {
+    unsafe registers {
         // The register name in the struct should be a lowercase version of the
         // register abbreviation, as written in the datasheet:
         0 => cr: Control::Register { Read, Write },

--- a/codegen/src/ast.rs
+++ b/codegen/src/ast.rs
@@ -20,19 +20,19 @@ use syn::{Attribute, Ident, LitInt, Path, Type, TypePath, Visibility};
 /// # use tock_registers::{Mmio32, Read, Write};
 /// # fn main() {}
 /// tock_registers::internal::register_map! {
-///     ::tock_registers             // The prepended $crate
-///     //! Global doc comment       // This doc comment should attach to everything in the macro.
-///     #![buses(Mmio32)]            // Global buses attribute
-///     a: u8 { Read, Write },       // A register defined by primitive type and operation list
-///     /// Doc comment              // Doc comment that should attach to `b`
-///     pub b: [a; 2],               // A register array that refers to another definition
-///     /// Doc comment              // Doc comment that should attach to `foo`
-///     pub foo {                    // Start of a register block
-///         0 => c: u8 { Read },     // Field register defined by primitive type and operation list
-///         1 => _: 1,               // Padding of size 1 byte
-///         2 => d: a,               // Field register that refers to another definition
-///         /// Doc comment          // Doc comment that should attach to `e`
-///         3 => e: [b; 2],          // Field array register that contains another definition
+///     ::tock_registers              // The prepended $crate
+///     //! Global doc comment        // This doc comment should attach to everything in the macro.
+///     #![buses(Mmio32)]             // Global buses attribute
+///     unsafe a: u8 { Read, Write }, // A register defined by primitive type and operation list
+///     /// Doc comment               // Doc comment that should attach to `b`
+///     pub unsafe b: [a; 2],         // A register array that refers to another definition
+///     /// Doc comment               // Doc comment that should attach to `foo`
+///     pub unsafe foo {              // Start of a register block
+///         0 => c: u8 { Read },      // Field register defined by primitive type and operation list
+///         1 => _: 1,                // Padding of size 1 byte
+///         2 => d: a,                // Field register that refers to another definition
+///         /// Doc comment           // Doc comment that should attach to `e`
+///         3 => e: [b; 2],           // Field array register that contains another definition
 ///     }
 /// }
 /// ```
@@ -51,15 +51,15 @@ pub struct Input {
 /// # fn main() {}
 /// tock_registers::mmio32_register_map! {
 ///     // `a` is a Layout
-///     a: u8 { Read, Write },
+///     unsafe a: u8 { Read, Write },
 ///
 ///     // `b` is a Layout, and it includes the doc comment before it.
 ///     /// Doc comment
-///     pub b: [a; 2],
+///     pub unsafe b: [a; 2],
 ///
 ///     // `foo` is a Layout, and it includes the doc comment and attributes before it.
 ///     /// Doc comment
-///     pub foo {
+///     pub unsafe foo {
 ///         0 => c: u8 { Read },  // Individual fields are `Field`s, not Layouts
 ///         1 => _: 1,
 ///         2 => d: a,
@@ -123,16 +123,16 @@ impl BusAttr {
 /// # use tock_registers::{Read, Write};
 /// # fn main() {}
 /// tock_registers::mmio32_register_map! {
-///     aa: u8 { Read, Write },
-///     //^^^^^^^^^^^^^^^^^^^^ Value::Single
+///     unsafe aa: u8 { Read, Write },
+///     //       ^^^^^^^^^^^^^^^^^^^^ Value::Single
 ///
 ///     /// Doc comment
-///     pub b: [aa; 2],
-///     //   ^^^^^^^^ Value::Single
+///     pub unsafe b: [aa; 2],
+///     //          ^^^^^^^^^ Value::Single
 ///
 ///     /// Doc comment
-///     pub foo {
-///     //      ^  The Value::Block starts here, and continues through the final }
+///     pub unsafe foo {
+///     //             ^  The Value::Block starts here, and continues through the final }
 ///         0 => c: u8 { Read },
 ///         1 => _: 1,
 ///         2 => d: aa,
@@ -152,9 +152,9 @@ pub enum Value {
 /// # use tock_registers::{Read, Write};
 /// # fn main() {}
 /// tock_registers::mmio32_register_map! {
-///     a: u8 { Read, Write },
+///     unsafe a: u8 { Read, Write },
 ///
-///     pub foo {
+///     pub unsafe foo {
 ///         0 => c: u8 { Read },
 ///       //^^^^^^^^^^^^^^^^^^^ Field
 ///
@@ -185,9 +185,9 @@ pub struct Field {
 /// # use tock_registers::Read;
 /// # fn main() {}
 /// tock_registers::mmio32_register_map! {
-///     status: u8 { Read },
+///     unsafe status: u8 { Read },
 ///
-///     foo {
+///     unsafe foo {
 ///         0 => c: u8 { Read },
 ///         //   ^^^^^^^^^^^^^^ FieldDef::Register
 ///
@@ -223,7 +223,7 @@ pub enum FieldDef {
 /// # fn main() {}
 /// tock_registers::register_map! {
 ///     #[buses(Mmio32, Mmio64)]
-///     foo {
+///     unsafe foo {
 ///         0 => c: u8 { Read },
 ///       //^ PerBusInt::Single
 ///
@@ -269,11 +269,11 @@ impl Index<usize> for PerBusInt {
 /// # use tock_registers::{Read, Write};
 /// # fn main() {}
 /// tock_registers::mmio32_register_map! {
-///     pub pin: u8 { Read, Write },
-///     //     ^^^^^^^^^^^^^^^^^^^^ Top-level RegisterSpec defining a new register
-///     pub pin_pair: [pin; 2],
-///     //          ^^^^^^^^^^ Top-level RegisterSpec referencing a separate definition (`status`)
-///     pub foo {
+///     pub unsafe pin: u8 { Read, Write },
+///     //            ^^^^^^^^^^^^^^^^^^^^ Top-level RegisterSpec defining a new register
+///     pub unsafe pin_pair: [pin; 2],
+///     //                 ^^^^^^^^^^ Top-level RegisterSpec referencing a separate definition
+///     pub unsafe foo {
 ///         0x0 => ctrl: u8 { Read, Write },
 ///         //         ^^^^^^^^^^^^^^^^^^^^ Field RegisterSpec defining a new register
 ///

--- a/codegen/src/block_test_all_fields.rs
+++ b/codegen/src/block_test_all_fields.rs
@@ -17,7 +17,7 @@ fn all_field_types_example() {
     let input = quote! {
         ::tock_registers
         #[buses(Mmio32, Mmio64)]
-        pub foo {
+        pub unsafe foo {
             0 => scalar_definition: u8 { Read, Dance<Waltz> },
             1 => array_definition: [[u8; 2]; 3] { Read, Write },
             7 => _: 1, // Padding

--- a/codegen/src/block_test_docs.rs
+++ b/codegen/src/block_test_docs.rs
@@ -22,7 +22,7 @@ fn doc_comments() {
         //! Doc comment D
         /// Doc comment E
         /// Doc comment F
-        pub foo {
+        pub unsafe foo {
             /// Doc comment G
             /// Doc comment H
             0 => scalar_definition: u8 { Read, Write },
@@ -142,11 +142,9 @@ fn doc_comments() {
             impl<B: Bus> Real<B> {
                 /// Constructs an accessor for this register or register block.
                 /// # Safety
-                /// 1. `address` must point to register(s) on the bus corresponding to
-                ///    `B`.
-                /// 2. The register(s)' definition (as provided to the
-                ///    `tock_registers::register_map!` macro) must correctly
-                ///    describe the pointed-to register(s).
+                /// 1. `address` must point to register(s) corresponding to this
+                ///    register map.
+                /// 2. Those registers must be on the bus corresponding to `B`.
                 /// 3. The returned register accessor must not be used in a way that
                 ///    causes data races. The exact requirements depend on the hardware,
                 ///    but it's usually best to access a register from only one thread
@@ -213,11 +211,9 @@ fn doc_comments() {
             impl<B: Bus> real_scalar_definition<B> {
                 /// Constructs an accessor for this register or register block.
                 /// # Safety
-                /// 1. `address` must point to register(s) on the bus corresponding to
-                ///    `B`.
-                /// 2. The register(s)' definition (as provided to the
-                ///    `tock_registers::register_map!` macro) must correctly
-                ///    describe the pointed-to register(s).
+                /// 1. `address` must point to register(s) corresponding to this
+                ///    register map.
+                /// 2. Those registers must be on the bus corresponding to `B`.
                 /// 3. The returned register accessor must not be used in a way that
                 ///    causes data races. The exact requirements depend on the hardware,
                 ///    but it's usually best to access a register from only one thread
@@ -250,11 +246,9 @@ fn doc_comments() {
             impl<B: Bus> real_array_definition<B> {
                 /// Constructs an accessor for this register or register block.
                 /// # Safety
-                /// 1. `address` must point to register(s) on the bus corresponding to
-                ///    `B`.
-                /// 2. The register(s)' definition (as provided to the
-                ///    `tock_registers::register_map!` macro) must correctly
-                ///    describe the pointed-to register(s).
+                /// 1. `address` must point to register(s) corresponding to this
+                ///    register map.
+                /// 2. Those registers must be on the bus corresponding to `B`.
                 /// 3. The returned register accessor must not be used in a way that
                 ///    causes data races. The exact requirements depend on the hardware,
                 ///    but it's usually best to access a register from only one thread

--- a/codegen/src/block_test_empty.rs
+++ b/codegen/src/block_test_empty.rs
@@ -13,7 +13,7 @@ fn empty() {
     let input = quote! {
         ::tock_registers
         #[bus(Mmio32)]
-        pub foo {}
+        pub unsafe foo {}
     };
     let interface_comment = interface_doc_comment();
     let bus_comment = bus_doc_comment();

--- a/codegen/src/block_test_offsets.rs
+++ b/codegen/src/block_test_offsets.rs
@@ -15,7 +15,7 @@ fn offsets() {
     let input = quote! {
         ::tock_registers
         #[buses(Mmio32, Mmio64)]
-        pub foo {
+        pub unsafe foo {
             0 => variable_size: usize { Read },
             [4, 8] => size_variable_pos: u32 { Read },
             #[aliased]

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -127,11 +127,9 @@ fn new_doc_comment() -> TokenStream {
     quote! {
         /// Constructs an accessor for this register or register block.
         /// # Safety
-        /// 1. `address` must point to register(s) on the bus corresponding to
-        ///    `B`.
-        /// 2. The register(s)' definition (as provided to the
-        ///    `tock_registers::register_map!` macro) must correctly
-        ///    describe the pointed-to register(s).
+        /// 1. `address` must point to register(s) corresponding to this
+        ///    register map.
+        /// 2. Those registers must be on the bus corresponding to `B`.
         /// 3. The returned register accessor must not be used in a way that
         ///    causes data races. The exact requirements depend on the hardware,
         ///    but it's usually best to access a register from only one thread

--- a/codegen/src/parse.rs
+++ b/codegen/src/parse.rs
@@ -73,10 +73,12 @@ impl Parse for Input {
 impl Parse for Layout {
     fn parse(input: ParseStream) -> Result<Layout> {
         let (docs, bus) = layout_attributes(Attribute::parse_outer(input)?)?;
+        let visibility = input.parse()?;
+        input.parse::<Token![unsafe]>()?;
         Ok(Layout {
             docs,
             bus,
-            visibility: input.parse()?,
+            visibility,
             name: input.parse()?,
             value: input.parse()?,
         })

--- a/codegen/src/parse_tests.rs
+++ b/codegen/src/parse_tests.rs
@@ -12,7 +12,7 @@ use syn::{parse2, parse_quote, Type};
 fn bus() {
     use crate::ast::BusAttr::{Bus, Buses};
 
-    let error = parse2::<Input>(quote![::tock_registers b: a]).unwrap_err();
+    let error = parse2::<Input>(quote![::tock_registers unsafe b: a]).unwrap_err();
     assert!(error.to_string().contains("no bus specified"));
 
     // Shortcuts so the assert_eq!() calls don't line-wrap.
@@ -22,9 +22,9 @@ fn bus() {
 
     let input: Input = parse_quote! {
         ::tock_registers
-        #[bus(Mmio32)] a: r,
-        #[buses(Mmio32)] b: r,
-        #[buses(Mmio32, Mmio64)] c: r,
+        #[bus(Mmio32)] unsafe a: r,
+        #[buses(Mmio32)] unsafe b: r,
+        #[buses(Mmio32, Mmio64)] unsafe c: r,
     };
     assert_eq!(input.layouts[0].bus, Bus(mmio32()));
     assert_eq!(input.layouts[1].bus, Buses(vec![mmio32()]));
@@ -32,10 +32,10 @@ fn bus() {
 
     let input: Input = parse_quote! {
         ::tock_registers #![bus(Mmio32)]
-        a: r,
-        #[bus(Mmio64)] b: r,
-        #[buses(Mmio64)] c: r,
-        #[buses(Mmio32Nullable, Mmio64)] d: r,
+        unsafe a: r,
+        #[bus(Mmio64)] unsafe b: r,
+        #[buses(Mmio64)] unsafe c: r,
+        #[buses(Mmio32Nullable, Mmio64)] unsafe d: r,
     };
     assert_eq!(input.layouts[0].bus, Bus(mmio32()));
     assert_eq!(input.layouts[1].bus, Bus(mmio64()));
@@ -44,10 +44,10 @@ fn bus() {
 
     let input: Input = parse_quote! {
         ::tock_registers #![buses(Mmio32)]
-        a: r,
-        #[bus(Mmio64)] b: r,
-        #[buses(Mmio64)] c: r,
-        #[buses(Mmio32Nullable, Mmio64)] d: r,
+        unsafe a: r,
+        #[bus(Mmio64)] unsafe b: r,
+        #[buses(Mmio64)] unsafe c: r,
+        #[buses(Mmio32Nullable, Mmio64)] unsafe d: r,
     };
     assert_eq!(input.layouts[0].bus, Buses(vec![mmio32()]));
     assert_eq!(input.layouts[1].bus, Bus(mmio64()));
@@ -56,20 +56,22 @@ fn bus() {
 
     let input: Input = parse_quote! {
         ::tock_registers #![buses(Mmio32, Mmio32Nullable)]
-        a: r,
-        #[bus(Mmio64)] b: r,
-        #[buses(Mmio64)] c: r,
-        #[buses(Mmio32Nullable, Mmio64)] d: r,
+        unsafe a: r,
+        #[bus(Mmio64)] unsafe b: r,
+        #[buses(Mmio64)] unsafe c: r,
+        #[buses(Mmio32Nullable, Mmio64)] unsafe d: r,
     };
     assert_eq!(input.layouts[0].bus, Buses(vec![mmio32(), mmio32null()]));
     assert_eq!(input.layouts[1].bus, Bus(mmio64()));
     assert_eq!(input.layouts[2].bus, Buses(vec![mmio64()]));
     assert_eq!(input.layouts[3].bus, Buses(vec![mmio32null(), mmio64()]));
 
-    let error = parse2::<Input>(quote![::tock_registers #![bus(A)] #![buses(B)] b: a]).unwrap_err();
+    let error =
+        parse2::<Input>(quote![::tock_registers #![bus(A)] #![buses(B)] unsafe b: a]).unwrap_err();
     assert!(error.to_string().contains("multiple bus attributes"));
 
-    let error = parse2::<Input>(quote![::tock_registers #[buses(A)] #[bus(B)] b: a]).unwrap_err();
+    let error =
+        parse2::<Input>(quote![::tock_registers #[buses(A)] #[bus(B)] unsafe b: a]).unwrap_err();
     assert!(error.to_string().contains("multiple bus attributes"));
 }
 
@@ -77,14 +79,15 @@ fn bus() {
 // of sizes for padding does not match the number of buses for that layout.
 #[test]
 fn bus_count_mismatches() {
-    let error =
-        parse2::<Input>(quote![::tock_registers #[bus(Port)] a { [0, 1] => a: u8 { Read } } ])
-            .unwrap_err()
-            .to_string();
+    let error = parse2::<Input>(
+        quote![::tock_registers #[bus(Port)] unsafe a { [0, 1] => a: u8 { Read } } ],
+    )
+    .unwrap_err()
+    .to_string();
     assert!(error.contains("number of offsets (2) does not match number of buses (1)"));
 
     let error =
-        parse2::<Input>(quote![::tock_registers #![buses(Mmio32, Port)] a { 0 => _: [1] } ])
+        parse2::<Input>(quote![::tock_registers #![buses(Mmio32, Port)] unsafe a { 0 => _: [1] } ])
             .unwrap_err()
             .to_string();
     assert!(error.contains("number of sizes (1) does not match number of buses (2)"));

--- a/codegen/src/single_test_array.rs
+++ b/codegen/src/single_test_array.rs
@@ -17,7 +17,7 @@ fn flat_array_definition_example() {
     let input = quote! {
         ::tock_registers
         #[buses(Mmio32, Mmio64)]
-        pub foo: [u8; 2] { Read, Write }
+        pub unsafe foo: [u8; 2] { Read, Write }
     };
     let interface_comment = interface_doc_comment();
     let bus_comment = bus_doc_comment();
@@ -83,7 +83,7 @@ fn nested_array_definition_example() {
     let input = quote! {
         ::tock_registers
         #[buses(Mmio32, Mmio64)]
-        pub foo: [[u8; 2]; 3] { Read, Write }
+        pub unsafe foo: [[u8; 2]; 3] { Read, Write }
     };
     let interface_comment = interface_doc_comment();
     let bus_comment = bus_doc_comment();
@@ -149,7 +149,7 @@ fn flat_array_reference_example() {
     let input = quote! {
         ::tock_registers
         #[buses(Mmio32, Mmio64)]
-        pub foo: [status; 2],
+        pub unsafe foo: [status; 2],
     };
     let interface_comment = interface_doc_comment();
     let bus_comment = bus_doc_comment();
@@ -184,7 +184,7 @@ fn nested_array_reference_example() {
     let input = quote! {
         ::tock_registers
         #[buses(Mmio32, Mmio64)]
-        pub foo: [[status; 2]; 3],
+        pub unsafe foo: [[status; 2]; 3],
     };
     let interface_comment = interface_doc_comment();
     let bus_comment = bus_doc_comment();

--- a/codegen/src/single_test_docs.rs
+++ b/codegen/src/single_test_docs.rs
@@ -22,7 +22,7 @@ fn scalar_definition() {
         //! Doc comment D
         /// Doc comment E
         /// Doc comment F
-        pub foo: u8 { Read, Write },
+        pub unsafe foo: u8 { Read, Write },
     };
     let expected = quote! {
         /// Doc comment A
@@ -53,11 +53,9 @@ fn scalar_definition() {
             impl<B: Bus> Real<B> {
                 /// Constructs an accessor for this register or register block.
                 /// # Safety
-                /// 1. `address` must point to register(s) on the bus corresponding to
-                ///    `B`.
-                /// 2. The register(s)' definition (as provided to the
-                ///    `tock_registers::register_map!` macro) must correctly
-                ///    describe the pointed-to register(s).
+                /// 1. `address` must point to register(s) corresponding to this
+                ///    register map.
+                /// 2. Those registers must be on the bus corresponding to `B`.
                 /// 3. The returned register accessor must not be used in a way that
                 ///    causes data races. The exact requirements depend on the hardware,
                 ///    but it's usually best to access a register from only one thread
@@ -96,7 +94,7 @@ fn array_definition() {
         //! Doc comment D
         /// Doc comment E
         /// Doc comment F
-        pub foo: [u8; 2] { Read, Write }
+        pub unsafe foo: [u8; 2] { Read, Write }
     };
     let expected = quote! {
         /// Doc comment A
@@ -132,11 +130,9 @@ fn array_definition() {
             impl<B: Bus> Element<B> {
                 /// Constructs an accessor for this register or register block.
                 /// # Safety
-                /// 1. `address` must point to register(s) on the bus corresponding to
-                ///    `B`.
-                /// 2. The register(s)' definition (as provided to the
-                ///    `tock_registers::register_map!` macro) must correctly
-                ///    describe the pointed-to register(s).
+                /// 1. `address` must point to register(s) corresponding to this
+                ///    register map.
+                /// 2. Those registers must be on the bus corresponding to `B`.
                 /// 3. The returned register accessor must not be used in a way that
                 ///    causes data races. The exact requirements depend on the hardware,
                 ///    but it's usually best to access a register from only one thread
@@ -177,7 +173,7 @@ fn scalar_reference() {
         //! Doc comment D
         /// Doc comment E
         /// Doc comment F
-        pub foo: status,
+        pub unsafe foo: status,
     };
     let expected = quote! {
         /// Doc comment A
@@ -219,7 +215,7 @@ fn array_reference() {
         //! Doc comment D
         /// Doc comment E
         /// Doc comment F
-        pub foo: [[status; 2]; 3],
+        pub unsafe foo: [[status; 2]; 3],
     };
     let expected = quote! {
         /// Doc comment A

--- a/codegen/src/single_test_scalar.rs
+++ b/codegen/src/single_test_scalar.rs
@@ -16,7 +16,7 @@ fn scalar_definition_example() {
     let input = quote! {
         ::tock_registers
         #[buses(Mmio32, Mmio64)]
-        pub foo: u8 { Read, Write },
+        pub unsafe foo: u8 { Read, Write },
     };
     let interface_comment = interface_doc_comment();
     let bus_comment = bus_doc_comment();
@@ -88,7 +88,7 @@ fn scalar_reference_example() {
     let input = quote! {
         ::tock_registers
         #[buses(Mmio32, Mmio64)]
-        pub foo: status,
+        pub unsafe foo: status,
     };
     let interface_comment = interface_doc_comment();
     let bus_comment = bus_doc_comment();
@@ -124,7 +124,7 @@ fn generic_operation() {
     let input = quote! {
         ::tock_registers
         #[bus(Mmio32)]
-        foo: u8 { Dance<Waltz> },
+        unsafe foo: u8 { Dance<Waltz> },
     };
     let interface_comment = interface_doc_comment();
     let bus_comment = bus_doc_comment();

--- a/doc/AddingRegisterTypes.md
+++ b/doc/AddingRegisterTypes.md
@@ -113,7 +113,7 @@ use my_bus_crate::{MyBus, MyOperation};
 
 tock_registers::register_map! {
     #[bus(MyBus)]
-    foo {
+    unsafe foo {
         0 => control: u8 { MyOperation },
     }
 }

--- a/doc/Terminology.md
+++ b/doc/Terminology.md
@@ -36,10 +36,10 @@ Examples:
 ```rust
 mmio32_register_map! {
     // A single register layout
-    a: u8 { Read },
+    unsafe a: u8 { Read },
 
     // A register block layout
-    b {
+    unsafe b {
         // `c` is *not* a layout, it is a field of the register block
         0 => c: u8 { Read, Write },
     },
@@ -48,7 +48,7 @@ mmio32_register_map! {
     // block. This is because register_map! is not aware that the element type
     // is a register block, it merely sees that it uses the single register
     // syntax.
-    d: b,
+    unsafe d: b,
 }
 ```
 
@@ -56,7 +56,7 @@ Each field in a register block can be either a register or padding:
 
 ```rust
 mmio32_register_map! {
-    uart {
+    unsafe uart {
         0 => status: u8 { Read },       // `status` is a field.
         1 => _,                         // padding is a field.
         2 => ctrl: u8 { Read, Write },  // `ctrl` is a field.
@@ -74,9 +74,9 @@ Examples:
 
 ```rust
 mmio32_register_map! {
-    a: u8 { Read },  // definition
-    b: a,            // reference (refers to `a`)
-    c {
+    unsafe a: u8 { Read },  // definition
+    unsafe b: a,            // reference (refers to `a`)
+    unsafe c {
         0 => d: u8 { Read },  // definition
         1 => e: a,            // reference (refers to `a`)
     },
@@ -88,9 +88,9 @@ based on whether its type specification contains an array:
 
 ```rust
 mmio32_register_map! {
-    a: u8 { Read },                // A scalar register
-    b: [u8; 2] { Read },           // An array register
-    c {
+    unsafe a: u8 { Read },         // A scalar register
+    unsafe b: [u8; 2] { Read },    // An array register
+    unsafe c {
         0 => d: u8 { Read },       // A scalar register field
         1 => e: [u8; 2] { Read },  // An array register field
     },
@@ -99,13 +99,13 @@ mmio32_register_map! {
     // "array" is based only on the syntax of the register/field, not based on
     // what it points to. Therefore:
 
-    f: b,                // A scalar register
-    g: [a; 2],           // An array register
-    h {
+    unsafe f: b,         // A scalar register
+    unsafe g: [a; 2],    // An array register
+    unsafe h {
         0 => i: b,       // A scalar register field
         1 => j: [a; 2],  // An array register field
     },
-    k: c,                // A scalar register
+    unsafe k: c,         // A scalar register
 }
 ```
 
@@ -113,13 +113,13 @@ To sum it all up:
 
 ```rust
 mmio32_register_map! {
-    a: u8 { Read },       // A single scalar register definition layout
-    b: a,                 // A single scalar register reference layout
-    c: [u8; 2] { Read },  // A single array register definition layout
-    d: [a; 2],            // A single array register reference layout
+    unsafe a: u8 { Read },       // A single scalar register definition layout
+    unsafe b: a,                 // A single scalar register reference layout
+    unsafe c: [u8; 2] { Read },  // A single array register definition layout
+    unsafe d: [a; 2],            // A single array register reference layout
 
     // A register block layout
-    e {
+    unsafe e {
         0 => f: u8 { Read },       // A scalar register definition field
         1 => g: a,                 // A scalar register reference field
         2 => h: [u8; 2] { Read },  // An array register definition field

--- a/doc/UnitTesting.md
+++ b/doc/UnitTesting.md
@@ -15,7 +15,7 @@ use tock_registers::{mmio32_register_map, Mmio32, Read};
 
 mmio32_register_map! {
     /// Registers for a hardware device that generates random numbers.
-    pub rng {
+    pub unsafe rng {
         /// This register returns a new random value on every read. It can be read concurrently by
         /// multiple cores, returning separate random data on each core.
         0 => random_byte: u8 { Read },

--- a/examples/doc_comments.rs
+++ b/examples/doc_comments.rs
@@ -9,27 +9,27 @@ use tock_registers::{mmio32_register_map, Read, Write};
 
 mmio32_register_map! {
     /// Doc comment on a register definition.
-    pub scalar_definition: u8 { Read },
+    pub unsafe scalar_definition: u8 { Read },
 }
 
 mmio32_register_map! {
     /// Another doc comment on a register definition.
-    pub array_definition: [u8; 3] { Read },
+    pub unsafe array_definition: [u8; 3] { Read },
 }
 
 mmio32_register_map! {
     /// Doc comment on a register reference.
-    pub scalar_reference: scalar_definition,
+    pub unsafe scalar_reference: scalar_definition,
 }
 
 mmio32_register_map! {
     /// Another doc comment on a register reference.
-    pub array_reference: [scalar_reference; 2],
+    pub unsafe array_reference: [scalar_reference; 2],
 }
 
 mmio32_register_map! {
     /// Doc comment on a register block.
-    pub foo {
+    pub unsafe foo {
         // Note: you cannot have an inner doc comment here.
 
         /// You can have doc comments on each field of a register block.
@@ -45,10 +45,10 @@ mmio32_register_map! {
 
 mmio32_register_map! {
     /// Doc comment that only applies to buttons.
-    pub buttons: u8 { Read },
+    pub unsafe buttons: u8 { Read },
 
     /// Another doc that only applies to pins.
-    pub pins: [u8; 3] { Read },
+    pub unsafe pins: [u8; 3] { Read },
 }
 
 fn main() {}

--- a/examples/generics.rs
+++ b/examples/generics.rs
@@ -98,13 +98,14 @@ pub struct Basket;
 #[derive(Debug)]
 pub struct Disco;
 
-register_map![#[buses(LiteX<8, 32>, LiteX<32, 32>)] a: u8 { Read, Dance<Tango>, Dance<Waltz> }];
-register_map![#[buses(LiteX<8, 32>, LiteX<32, 32>)] b: [u8; 2] { Read, Ball<Use = Basket> }];
-register_map![#[buses(LiteX<8, 32>, LiteX<32, 32>)] c: a];
-register_map![#[buses(LiteX<8, 32>, LiteX<32, 32>)] d: [b; 2]];
+register_map![#[buses(LiteX<8, 32>, LiteX<32, 32>)]
+    unsafe a: u8 { Read, Dance<Tango>, Dance<Waltz> }];
+register_map![#[buses(LiteX<8, 32>, LiteX<32, 32>)] unsafe b: [u8; 2] { Read, Ball<Use = Basket> }];
+register_map![#[buses(LiteX<8, 32>, LiteX<32, 32>)] unsafe c: a];
+register_map![#[buses(LiteX<8, 32>, LiteX<32, 32>)] unsafe d: [b; 2]];
 register_map! {
     #[buses(LiteX<8, 32>, LiteX<32, 32>)]
-    e {
+    unsafe e {
         0 => f: u8 { Read, Dance<Tango> },
         [4, 4] => g: [u8; 2] { Read, Ball<Use = Disco> },
         12 => h: c,

--- a/examples/rng.rs
+++ b/examples/rng.rs
@@ -13,7 +13,9 @@ use tock_registers::{mmio32_register_map, Mmio32, Read};
 // independent of underlying implementation (i.e., real hardware or a mock).
 mmio32_register_map! {
     /// Registers for a hardware device that generates random numbers.
-    pub rng {
+    ///
+    /// # Safety: This matches the (fictional) hardware.
+    pub unsafe rng {
         /// This register returns a new random value on every read. It can be
         /// read concurrently by multiple cores, returning separate random data
         /// on each core.

--- a/examples/typestate.rs
+++ b/examples/typestate.rs
@@ -51,7 +51,7 @@ use tock_registers::{mmio64_register_map, Mmio64};
 use typestate::TypestateWrite;
 
 mmio64_register_map! {
-    temperature {
+    unsafe temperature {
         // Declare that task_start and task_stop may only be written by the typestate module.
         0 => task_start: u32 { TypestateWrite<Token = wrapper::Token> },
         4 => task_stop: u32 { TypestateWrite<Token = wrapper::Token> },

--- a/expand_macros/test/src/unexpanded.rs
+++ b/expand_macros/test/src/unexpanded.rs
@@ -12,12 +12,12 @@ use tock_registers::{Mmio32, Mmio64, Read, Write};
 
 register_map! {
     #![buses(Mmio32, Mmio64)]
-    a: u8 { Read, Write },
-    b: u8 { Read, Write },
+    unsafe a: u8 { Read, Write },
+    unsafe b: u8 { Read, Write },
 }
 
 ::tock_registers::mmio32_register_map! {
-    c {
+    unsafe c {
         0 => scalar_definition: u8 { Read, Write },
         1 => array_definition: [[u8; 2]; 3] { Read, Write },
         7 => _: 1,
@@ -27,7 +27,7 @@ register_map! {
 }
 
 tock_registers::mmio64_register_map! {
-    d: a,
+    unsafe d: a,
 }
 
 // Uncomment this to verify that tock_registers is being used without the proc_macros feature (this

--- a/src/array.rs
+++ b/src/array.rs
@@ -48,7 +48,7 @@ pub trait RegisterArray<L: Len>: Copy {
 /// # fn main() {}
 /// # use tock_registers::{mmio32_register_map, Read, Write};
 /// mmio32_register_map! {
-///     foo {
+///     unsafe foo {
 ///         0 => a: [[[u8; 2]; 2]; 2] { Read, Write },
 ///     }
 /// }
@@ -80,9 +80,9 @@ pub trait RegisterArray<L: Len>: Copy {
 /// # fn main() {}
 /// # use tock_registers::{mmio32_register_map, Read, Write};
 /// mmio32_register_map! {
-///     a: [u8; 2] { Read, Write },
-///     b: [a; 2],
-///     foo {
+///     unsafe a: [u8; 2] { Read, Write },
+///     unsafe b: [a; 2],
+///     unsafe foo {
 ///         // This results in a compile error too
 ///         0 => c: [b; 2],
 ///     },

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -62,10 +62,8 @@ pub unsafe trait Span: Copy {
 
     /// Constructs an accessor for a register span.
     /// # Safety
-    /// 1. `address` must point to register(s) on the bus corresponding to `Self::Address`.
-    /// 2. The register(s)' definition (as provided to the
-    ///    [`register_map`](crate::register_map) macro) must correctly describe the pointed-to
-    ///    register(s).
+    /// 1. `address` must point to register(s) described by this register map.
+    /// 2. Those registers must be on the bus corresponding to `Self::Address`.
     /// 3. The returned register span accessor must not be used in a way that causes data races.
     ///    The exact requirements depend on the hardware, but it's usually best to access a
     ///    register span from only one thread at a time.
@@ -163,10 +161,8 @@ where
 {
     /// Constructs a new RegisterSender for the given register span.
     /// # Safety
-    /// 1. `address` must point to register(s) on the bus corresponding to `Self::Address`.
-    /// 2. The register(s)' definition (as provided to the
-    ///    [`register_map`](crate::register_map) macro) must correctly describe the pointed-to
-    ///    register(s).
+    /// 1. `address` must point to register(s) described by this register map.
+    /// 2. Those registers must be on the bus corresponding to `Self::Address`.
     /// 3. Nothing other than handles returned by [`borrow`](Self::borrow) (and handles derived
     ///    from them) may be used to access this register span.
     pub unsafe fn new(address: R::Address) -> Self {

--- a/src/fake_register.rs
+++ b/src/fake_register.rs
@@ -16,7 +16,7 @@ use core::marker::PhantomData;
 /// # use tock_registers::{FakeRegister, NoAccess, Read, Safe};
 /// tock_registers::mmio32_register_map! {
 ///     /// A random number generator, which simply returns a random byte on each read.
-///     rng {
+///     unsafe rng {
 ///         0 => random_byte: u8 { Read },
 ///     }
 /// }
@@ -158,7 +158,7 @@ impl sealed::Access for Safe {}
 /// # use tock_registers::{LocalRegisterCopy, Read, Write, Safe};
 /// mmio32_register_map! {
 ///     /// An array of registers that remember values written into them.
-///     storage {
+///     unsafe storage {
 ///         0 => scratch: [u8; 4] { Read, Write },
 ///     }
 /// }

--- a/src/map.rs
+++ b/src/map.rs
@@ -14,12 +14,15 @@
 /// use tock_registers::{register_map, Mmio32, Read, Write};
 /// register_map! {
 ///     #[bus(Mmio32)]
-///     ctrl: u8 { Read, Write },
+///     unsafe ctrl: u8 { Read, Write },
 /// }
 /// ```
 /// This declares an MMIO register (for 32-bit systems) called `ctrl`, whose data type is `u8`,
-/// which can be read from or written to. This definition generates a module that contains the
-/// following items:
+/// which can be read from or written to. Declaring a register is `unsafe` because an incorrect
+/// register map can cause undefined behavior. We suggest adding a `/// # Safety` comment
+/// describing exactly which peripheral (or part of a peripheral) the definition matches.
+///
+/// This definition generates a module that contains the following items:
 /// ```
 /// # fn main() {}
 /// # use tock_registers::{Mmio32, Read, Write};
@@ -57,7 +60,7 @@
 /// register_bitfields! [u8,
 ///     Control [OFF 0, ON 1],
 /// ];
-/// mmio32_register_map![ctrl: Control::Register { Read, Write }];
+/// mmio32_register_map![unsafe ctrl: Control::Register { Read, Write }];
 /// ```
 ///
 /// # Register arrays
@@ -65,9 +68,9 @@
 /// ```
 /// # fn main() {}
 /// use tock_registers::{mmio32_register_map, Read, Write};
-/// mmio32_register_map![buttons: [u8; 8] { Read }];
+/// mmio32_register_map![unsafe buttons: [u8; 8] { Read }];
 /// // You can nest array types as well.
-/// mmio32_register_map![led_grid: [[u8; 8]; 8] { Read, Write }];
+/// mmio32_register_map![unsafe led_grid: [[u8; 8]; 8] { Read, Write }];
 /// ```
 /// In the generated module, the `Interface` trait will depend on
 /// [`RegisterArray`](crate::RegisterArray) instead of `Register`, and the `RegisterArray::Element`
@@ -79,11 +82,11 @@
 /// # fn main() {}
 /// use tock_registers::{mmio32_register_map, Read};
 /// // The original register definition.
-/// mmio32_register_map![button: u8 { Read }];
+/// mmio32_register_map![unsafe button: u8 { Read }];
 /// // A clone of the register.
-/// mmio32_register_map![button2: button];
+/// mmio32_register_map![unsafe button2: button];
 /// // An array of buttons:
-/// mmio32_register_map![button_array: [button; 8]];
+/// mmio32_register_map![unsafe button_array: [button; 8]];
 /// ```
 /// The data type and operations that a register has are inherited from the register it refers to
 /// (so `button2` implements `Read`, and `button_array` is an array of readable registers). These
@@ -96,7 +99,7 @@
 /// # fn main() {}
 /// use tock_registers::{mmio32_register_map, Read, Write};
 /// mmio32_register_map! {
-///     uart {
+///     unsafe uart {
 ///         0 => status: u8 { Read },
 ///         1 => ctrl: u16 { Read, Write },
 ///         3 => buffer: u8 { Read, Write },
@@ -136,13 +139,13 @@
 ///     Control [OFF 0, INPUT 1, OUTPUT 2],
 /// ];
 /// mmio32_register_map! {
-///     gpio_pin {
+///     unsafe gpio_pin {
 ///         0 => control: Control::Register { Read, Write },
 ///         1 => value: u8 { Read, Write },
 ///     }
 /// }
 /// mmio32_register_map! {
-///     pinmux {
+///     unsafe pinmux {
 ///         0 => status: u8 { Read },
 ///         // `pins` is an array of references to gpio_pin register blocks. This results in
 ///         // gpio_pin::control and gpio_pin::value being interleaved for a total of 32 bytes.
@@ -158,7 +161,7 @@
 /// # fn main() {}
 /// use tock_registers::{mmio32_register_map, Read, Write};
 /// mmio32_register_map! {
-///     uart {
+///     unsafe uart {
 ///         0 => status: u8 { Read },
 ///         // Padding is specified by replacing the field definition with a _
 ///         1 => _,
@@ -186,7 +189,7 @@
 ///     /// Uart with an unusual property: the "control" register and "status" register are located
 ///     /// at the same offset. Writes go to the control register, while reads go to the status
 ///     /// register.
-///     uart {
+///     unsafe uart {
 ///         0 => control: Control::Register { Write },
 ///         #[aliased]
 ///         0 => status: u8 { Read },
@@ -206,9 +209,9 @@
 /// ```
 /// # fn main() {}
 /// use tock_registers::{mmio32_register_map, Read};
-/// mmio32_register_map![pub button: u8 { Read }];     // pub mod button { ... }
-/// mmio32_register_map![pub(crate) button2: button];  // pub(crate) mod button2 { ... }
-/// mmio32_register_map![button_array: [button; 8]];   // mod button2 { ... }
+/// mmio32_register_map![pub unsafe button: u8 { Read }];     // pub mod button { ... }
+/// mmio32_register_map![pub(crate) unsafe button2: button];  // pub(crate) mod button2 { ... }
+/// mmio32_register_map![unsafe button_array: [button; 8]];   // mod button2 { ... }
 /// ```
 ///
 /// # Specifying multiple buses
@@ -220,7 +223,7 @@
 /// use tock_registers::{register_map, Mmio32, Mmio64, Read, Write};
 /// register_map! {
 ///     #[buses(Mmio32, Mmio64)]
-///     rng {
+///     unsafe rng {
 ///         0 => ctrl: u8 { Read, Write },
 ///         1 => random_byte: u8 { Read },
 ///     }
@@ -238,7 +241,7 @@
 /// use tock_registers::{register_map, Mmio32, Mmio64, Read, Write};
 /// register_map! {
 ///     #[buses(Mmio32, Mmio64)]
-///     dma_rng {
+///     unsafe dma_rng {
 ///         0 => address: usize { Read, Write },
 ///         [4, 8] => length: u32 { Read, Write },
 ///         // Padding can also move around, and have per-bus length.
@@ -256,7 +259,7 @@
 /// use tock_registers::{mmio32_register_map, Read, Write};
 /// mmio32_register_map! {
 ///     /// This is an outer doc comment, which will be copied to the generated `uart` module.
-///     uart {
+///     unsafe uart {
 ///         /// This doc comment will be copied onto `Interface::status()`.
 ///         0 => status: u8 { Read },
 ///         /// This doc comment will be copied onto `Interface::buffer()`.
@@ -279,12 +282,12 @@
 ///     #![buses(Mmio32, Mmio64)]
 ///     //! Inner doc comments are copied onto every declaration.
 ///     // Both `button` and `led` support both 32-bit and 64-bit MMIO.
-///     button: u8 { Read },
+///     unsafe button: u8 { Read },
 ///     /// You can still have outer doc comments per-declaration.
-///     led: u8 { Read, Write },
+///     unsafe led: u8 { Read, Write },
 ///     // But `touch` only supports 32-bit MMIO.
 ///     #[bus(Mmio32)]
-///     touch: u8 { Read },
+///     unsafe touch: u8 { Read },
 /// }
 /// ```
 ///

--- a/tests/all_block_fields.rs
+++ b/tests/all_block_fields.rs
@@ -11,9 +11,9 @@ use tock_registers::{mmio32_register_map, Read, Write};
 
 mmio32_register_map! {
     // External registers to reference.
-    a: u8 { Read, Write },
-    b: u8 { Write },
-    c {
+    unsafe a: u8 { Read, Write },
+    unsafe b: u8 { Write },
+    unsafe c {
         0 => scalar_definition: u8 { Read },
         1 => array_definition: [[u8; 2]; 3] { Read, Write },
         7 => _: 1,

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -13,7 +13,7 @@ use tock_registers::{
 use {array_demo::Interface as _, variable_increment::Interface as _};
 
 mmio32_register_map! {
-    variable_increment {
+    unsafe variable_increment {
         /// The amount to increment the shared counter by when `counter` is read.
         0 => increment: u8 { Read, Write },
         /// Accessor for the shared counter. Each time this is read, the shared counter is
@@ -23,7 +23,7 @@ mmio32_register_map! {
 
     /// A demonstration of register arrays. This type contains a single, shared counter that wraps
     /// modulo 256.
-    array_demo {
+    unsafe array_demo {
         /// Reading from the array with index i increments the counter by i+1, wrapping modulo 256.
         0 => counter: [u8; 3] { Read },
         /// A set of variable-counter-incrementers. These all access the same shared counter, but

--- a/tests/many_lints.rs
+++ b/tests/many_lints.rs
@@ -103,9 +103,9 @@ use tock_registers::{register_map, Mmio32, Mmio64, Read, Write};
 
 register_map! {
     #![buses(Mmio32, Mmio64)]
-    aa: u8 { Read, Write },
-    bb: u8 { Write },
-    cc {
+    unsafe aa: u8 { Read, Write },
+    unsafe bb: u8 { Write },
+    unsafe cc {
         0usize => scalar_definition: u8 { Read },
         1usize => array_definition: [[u8; 2]; 3] { Read, Write },
         7usize => _: [1usize, 1usize],

--- a/tests/mmio.rs
+++ b/tests/mmio.rs
@@ -12,9 +12,9 @@ use {inner_block::Interface as _, outer_block::Interface as _};
 register_map! {
     #![buses(Mmio32, Mmio64)]
     // External registers to reference.
-    a: u8 { Read, Write },
-    b: u16 { Read, Write },
-    inner_block {
+    unsafe a: u8 { Read, Write },
+    unsafe b: u16 { Read, Write },
+    unsafe inner_block {
         0 => scalar_definition: usize { Read, Write },
         [4, 8] => _: [4, 8],
         [8, 16] => array_definition: [[u32; 2]; 3] { Read, Write },
@@ -22,7 +22,7 @@ register_map! {
         [33, 41] => _,
         [36, 44] => array_reference: [[b; 2]; 3],
     },
-    outer_block {
+    unsafe outer_block {
         0 => scalar: u64 { Read, Write },
         #[aliased]
         1 => overlapped: u8 { Read, Write },

--- a/tests/multi_crate/child/src/lib.rs
+++ b/tests/multi_crate/child/src/lib.rs
@@ -11,10 +11,10 @@ use multi_crate_parent::scalar_definition;
 use multi_crate_parent::scalar_reference;
 
 tock_registers::mmio32_register_map! {
-    scalar_definition_reference: scalar_definition,
-    array_definition_reference: array_definition,
-    block_definition_reference: block_definition,
-    scalar_reference_reference: scalar_reference,
-    array_reference_reference: array_reference,
-    block_reference_reference: block_reference,
+    unsafe scalar_definition_reference: scalar_definition,
+    unsafe array_definition_reference: array_definition,
+    unsafe block_definition_reference: block_definition,
+    unsafe scalar_reference_reference: scalar_reference,
+    unsafe array_reference_reference: array_reference,
+    unsafe block_reference_reference: block_reference,
 }

--- a/tests/multi_crate/parent/src/lib.rs
+++ b/tests/multi_crate/parent/src/lib.rs
@@ -6,15 +6,15 @@
 use tock_registers::{mmio32_register_map, Read};
 
 mmio32_register_map! {
-    pub scalar_definition: u8 { Read },
-    pub array_definition: [u8; 2] { Read },
-    pub block_definition {
+    pub unsafe scalar_definition: u8 { Read },
+    pub unsafe array_definition: [u8; 2] { Read },
+    pub unsafe block_definition {
         0 => scalar_field: u8 { Read },
     }
 }
 
 mmio32_register_map! {
-    pub scalar_reference: scalar_definition,
-    pub array_reference: array_definition,
-    pub block_reference: block_definition,
+    pub unsafe scalar_reference: scalar_definition,
+    pub unsafe array_reference: array_definition,
+    pub unsafe block_reference: block_definition,
 }

--- a/tests/nested_arrays.rs
+++ b/tests/nested_arrays.rs
@@ -13,11 +13,11 @@
 use tock_registers::{mmio32_register_map, Read, Register, RegisterArray, Write};
 
 mmio32_register_map! {
-    pub a: [u8; 2] { Read, Write },
-    pub b: [a; 2],
-    pub c: [b; 2],
-    pub d: [c; 2],
-    pub e {
+    pub unsafe a: [u8; 2] { Read, Write },
+    pub unsafe b: [a; 2],
+    pub unsafe c: [b; 2],
+    pub unsafe d: [c; 2],
+    pub unsafe e {
         0 => array: [d; 2],
     }
 }

--- a/tests/no_prelude.rs
+++ b/tests/no_prelude.rs
@@ -13,9 +13,9 @@
 use ::tock_registers::{mmio32_register_map, Read, Write};
 
 mmio32_register_map! {
-    a: u8 { Read, Write },
-    b: u8 { Write },
-    c {
+    unsafe a: u8 { Read, Write },
+    unsafe b: u8 { Write },
+    unsafe c {
         0 => scalar_definition: u8 { Read },
         1 => array_definition: [[u8; 2]; 3] { Read, Write },
         7 => _: 1,
@@ -25,11 +25,11 @@ mmio32_register_map! {
 }
 
 mmio32_register_map! {
-    pub inner {
+    pub unsafe inner {
         [0] => ctrl: u8 { Read, Write },
     },
 
-    pub outer {
+    pub unsafe outer {
         [0] => ctrl: u8 { Read },
         [1] => inner: inner,
     },

--- a/tests/same_names.rs
+++ b/tests/same_names.rs
@@ -12,13 +12,13 @@
 use tock_registers::{mmio32_register_map, Read, Write};
 
 mmio32_register_map! {
-    pub inner {
+    pub unsafe inner {
         // We use an offset array to make the #name_offset entries exist in both the Bus
         // declaration and impls, as the name collision error tends to show up in the impls.
         [0] => ctrl: u8 { Read, Write },
     },
 
-    pub outer {
+    pub unsafe outer {
         [0] => ctrl: u8 { Read },
         [1] => inner: inner,
     },

--- a/tests/send_register.rs
+++ b/tests/send_register.rs
@@ -9,7 +9,7 @@ use std::{ptr::NonNull, sync::mpsc::channel, thread::spawn};
 use tock_registers::{mmio64_register_map, Mmio64, Read, RegisterSender, Write};
 
 mmio64_register_map! {
-    counter {
+    unsafe counter {
         0 => ctrl: u8 { Read, Write },
     }
 }


### PR DESCRIPTION
This moves the "this register map is a correct description of the hardware" safety invariant into the `register_map` call, thereby removing that invariant from the register handle constructors. This puts that safety invariant on the code that it applies to.

This is particularly useful in multi-crate use cases, where the `register_map!` invocation may be in a different crate from the constructor call. In that case, asserting the safety invariant in the `register_map!` crate is correct.

I suggest putting a `// Safety` comment that links to the corresponding datasheet and describes exactly which peripheral the register map matches.