### PR TITLE
rename: Len → Length, lens → lengths

### DIFF
--- a/codegen/src/block.rs
+++ b/codegen/src/block.rs
@@ -38,7 +38,7 @@ pub fn generate(env: Env, tock_registers: &Path, layout: &Layout, fields: &[Fiel
     let name = &layout.name;
     let interface_comment = interface_doc_comment();
     let mut interface_fields = TokenStream::new();
-    let lens_comment = lens_doc_comment();
+    let lengths_comment = lengths_doc_comment();
     let mut len_definitions = TokenStream::new();
     let bus_comment = bus_doc_comment();
     let mut bus_bounds = TokenStream::new();
@@ -134,12 +134,11 @@ pub fn generate(env: Env, tock_registers: &Path, layout: &Layout, fields: &[Fiel
         };
         // Loop that runs once for each level of array nesting.
         for (len_type, size) in len_types_sizes {
-            interface_bound =
-                quote![#tock_registers::RegisterArray<lens::#len_type, Element: #interface_bound>];
+            interface_bound = quote![#tock_registers::RegisterArray<lengths::#len_type, Element: #interface_bound>];
             len_definitions.extend(quote! {
                 impl #tock_registers::array::Len for #len_type { const LEN: usize = #size; }
             });
-            real = quote![#tock_registers::RealRegisterArray<#real, lens::#len_type>];
+            real = quote![#tock_registers::RealRegisterArray<#real, lengths::#len_type>];
         }
         interface_fields.extend(quote! {
             type #name: #interface_bound;
@@ -203,7 +202,7 @@ pub fn generate(env: Env, tock_registers: &Path, layout: &Layout, fields: &[Fiel
             #interface_comment pub trait Interface: #tock_registers::internal::core::marker::Copy {
                 #interface_fields
             }
-            #lens_comment pub mod lens { #len_definitions }
+            #lengths_comment pub mod lengths { #len_definitions }
             #bus_comment #[allow(clippy::trait_duplication_in_bounds)]
             pub trait Bus: #tock_registers::Address #bus_bounds + sealed::Bus {
                 const SIZE: usize;
@@ -258,7 +257,7 @@ pub fn interface_doc_comment() -> TokenStream {
     }
 }
 
-pub fn lens_doc_comment() -> TokenStream {
+pub fn lengths_doc_comment() -> TokenStream {
     quote! {
         /// Phantom types encoding the lengths of register arrays in this block.
         ///
@@ -266,7 +265,7 @@ pub fn lens_doc_comment() -> TokenStream {
         /// over register arrays in this block, for example:
         ///
         /// ```ignore
-        /// fn process<R: RegisterArray<my_block::lens::my_array>>(regs: R) { ... }
+        /// fn process<R: RegisterArray<my_block::lengths::my_array>>(regs: R) { ... }
         /// ```
     }
 }

--- a/codegen/src/block_test_all_fields.rs
+++ b/codegen/src/block_test_all_fields.rs
@@ -4,7 +4,7 @@
 // Copyright Better Bytes 2026.
 
 use crate::block::{
-    bus_doc_comment, field_struct_doc_comment, interface_doc_comment, lens_doc_comment,
+    bus_doc_comment, field_struct_doc_comment, interface_doc_comment, lengths_doc_comment,
     real_doc_comment,
 };
 use crate::{new_doc_comment, register_map, test_util::assert_tokens_eq, Env::ProcMacro};
@@ -29,7 +29,7 @@ fn all_field_types_example() {
         }
     };
     let interface_comment = interface_doc_comment();
-    let lens_comment = lens_doc_comment();
+    let lengths_comment = lengths_doc_comment();
     let bus_comment = bus_doc_comment();
     let real_comment = real_doc_comment();
     let new_comment = new_doc_comment();
@@ -46,25 +46,25 @@ fn all_field_types_example() {
                     ::tock_registers::Register<DataType = u8> + Read + Dance<Waltz>;
                 fn scalar_definition(self) -> Self::scalar_definition;
                 type array_definition: ::tock_registers::RegisterArray<
-                    lens::array_definition<1usize>,
-                    Element: ::tock_registers::RegisterArray<lens::array_definition<0usize>,
+                    lengths::array_definition<1usize>,
+                    Element: ::tock_registers::RegisterArray<lengths::array_definition<0usize>,
                         Element: ::tock_registers::Register<DataType = u8> + Read + Write> >;
                 fn array_definition(self) -> Self::array_definition;
                 type scalar_reference: a::Interface;
                 fn scalar_reference(self) -> Self::scalar_reference;
                 type array_reference: ::tock_registers::RegisterArray<
-                    lens::array_reference<1usize>, Element: ::tock_registers::RegisterArray<
-                        lens::array_reference<0usize>, Element: b::Interface> >;
+                    lengths::array_reference<1usize>, Element: ::tock_registers::RegisterArray<
+                        lengths::array_reference<0usize>, Element: b::Interface> >;
                 fn array_reference(self) -> Self::array_reference;
                 type flat_array_definition: ::tock_registers::RegisterArray<
-                    lens::flat_array_definition, Element:
+                    lengths::flat_array_definition, Element:
                         ::tock_registers::Register<DataType = u8> + Read>;
                 fn flat_array_definition(self) -> Self::flat_array_definition;
                 type flat_array_reference: ::tock_registers::RegisterArray<
-                    lens::flat_array_reference, Element: c::Interface>;
+                    lengths::flat_array_reference, Element: c::Interface>;
                 fn flat_array_reference(self) -> Self::flat_array_reference;
             }
-            #lens_comment pub mod lens {
+            #lengths_comment pub mod lengths {
                 pub enum array_definition<const N: usize> {}
                 impl ::tock_registers::array::Len for array_definition<0usize> { const LEN: usize = 2; }
                 impl ::tock_registers::array::Len for array_definition<1usize> { const LEN: usize = 3; }
@@ -179,7 +179,7 @@ fn all_field_types_example() {
                 }
                 type array_definition = ::tock_registers::RealRegisterArray<
                     ::tock_registers::RealRegisterArray<real_array_definition<B>,
-                        lens::array_definition<0usize> >, lens::array_definition<1usize> >;
+                        lengths::array_definition<0usize> >, lengths::array_definition<1usize> >;
                 fn array_definition(self) -> Self::array_definition {
                     unsafe {
                         Self::array_definition::new(
@@ -194,8 +194,8 @@ fn all_field_types_example() {
                     }
                 }
                 type array_reference = ::tock_registers::RealRegisterArray<
-                    ::tock_registers::RealRegisterArray<b::Real<B>, lens::array_reference<0usize>
-                    >, lens::array_reference<1usize> >;
+                    ::tock_registers::RealRegisterArray<b::Real<B>, lengths::array_reference<0usize>
+                    >, lengths::array_reference<1usize> >;
                 fn array_reference(self) -> Self::array_reference {
                     unsafe {
                         Self::array_reference::new(
@@ -203,7 +203,7 @@ fn all_field_types_example() {
                     }
                 }
                 type flat_array_definition = ::tock_registers::RealRegisterArray<
-                    real_flat_array_definition<B>, lens::flat_array_definition>;
+                    real_flat_array_definition<B>, lengths::flat_array_definition>;
                 fn flat_array_definition(self) -> Self::flat_array_definition {
                     unsafe {
                         Self::flat_array_definition::new(
@@ -211,7 +211,7 @@ fn all_field_types_example() {
                     }
                 }
                 type flat_array_reference =
-                    ::tock_registers::RealRegisterArray<c::Real<B>, lens::flat_array_reference>;
+                    ::tock_registers::RealRegisterArray<c::Real<B>, lengths::flat_array_reference>;
                 fn flat_array_reference(self) -> Self::flat_array_reference {
                     unsafe {
                         Self::flat_array_reference::new(

--- a/codegen/src/block_test_docs.rs
+++ b/codegen/src/block_test_docs.rs
@@ -55,8 +55,8 @@ fn doc_comments() {
                 /// Doc comment H
                 fn scalar_definition(self) -> Self::scalar_definition;
                 type array_definition: ::tock_registers::RegisterArray<
-                    lens::array_definition<1usize>, Element:
-                        ::tock_registers::RegisterArray<lens::array_definition<0usize>, Element:
+                    lengths::array_definition<1usize>, Element:
+                        ::tock_registers::RegisterArray<lengths::array_definition<0usize>, Element:
                             ::tock_registers::Register<DataType = u8> + Read + Write> >;
                 /// Doc comment I
                 /// Doc comment J
@@ -66,8 +66,8 @@ fn doc_comments() {
                 /// Doc comment L
                 fn scalar_reference(self) -> Self::scalar_reference;
                 type array_reference: ::tock_registers::RegisterArray<
-                    lens::array_reference<1usize>, Element: ::tock_registers::RegisterArray<
-                        lens::array_reference<0usize>, Element: b::Interface> >;
+                    lengths::array_reference<1usize>, Element: ::tock_registers::RegisterArray<
+                        lengths::array_reference<0usize>, Element: b::Interface> >;
                 /// Doc comment M
                 /// Doc comment N
                 fn array_reference(self) -> Self::array_reference;
@@ -78,9 +78,9 @@ fn doc_comments() {
             /// over register arrays in this block, for example:
             ///
             /// ```ignore
-            /// fn process<R: RegisterArray<my_block::lens::my_array>>(regs: R) { ... }
+            /// fn process<R: RegisterArray<my_block::lengths::my_array>>(regs: R) { ... }
             /// ```
-            pub mod lens {
+            pub mod lengths {
                 pub enum array_definition<const N: usize> {}
                 impl ::tock_registers::array::Len for
                     array_definition<0usize> { const LEN: usize = 2; }
@@ -180,7 +180,7 @@ fn doc_comments() {
                 }
                 type array_definition = ::tock_registers::RealRegisterArray<
                     ::tock_registers::RealRegisterArray<real_array_definition<B>,
-                    lens::array_definition<0usize> >, lens::array_definition<1usize> >;
+                    lengths::array_definition<0usize> >, lengths::array_definition<1usize> >;
                 fn array_definition(self) -> Self::array_definition {
                     unsafe {
                         Self::array_definition::new(
@@ -195,8 +195,8 @@ fn doc_comments() {
                     }
                 }
                 type array_reference = ::tock_registers::RealRegisterArray<
-                    ::tock_registers::RealRegisterArray<b::Real<B>, lens::array_reference<0usize>
-                    >, lens::array_reference<1usize> >;
+                    ::tock_registers::RealRegisterArray<b::Real<B>, lengths::array_reference<0usize>
+                    >, lengths::array_reference<1usize> >;
                 fn array_reference(self) -> Self::array_reference {
                     unsafe {
                         Self::array_reference::new(

--- a/codegen/src/block_test_empty.rs
+++ b/codegen/src/block_test_empty.rs
@@ -3,7 +3,7 @@
 // Copyright Tock Contributors 2026.
 // Copyright Better Bytes 2026.
 
-use crate::block::{bus_doc_comment, interface_doc_comment, lens_doc_comment, real_doc_comment};
+use crate::block::{bus_doc_comment, interface_doc_comment, lengths_doc_comment, real_doc_comment};
 use crate::{new_doc_comment, register_map, test_util::assert_tokens_eq, Env::External};
 use quote::quote;
 
@@ -16,7 +16,7 @@ fn empty() {
         pub foo {}
     };
     let interface_comment = interface_doc_comment();
-    let lens_comment = lens_doc_comment();
+    let lengths_comment = lengths_doc_comment();
     let bus_comment = bus_doc_comment();
     let real_comment = real_doc_comment();
     let new_comment = new_doc_comment();
@@ -25,7 +25,7 @@ fn empty() {
             #![allow(non_camel_case_types,dead_code,non_upper_case_globals)] use super::*;
             #interface_comment
             pub trait Interface: ::tock_registers::internal::core::marker::Copy {}
-            #lens_comment pub mod lens {}
+            #lengths_comment pub mod lengths {}
             #bus_comment #[allow(clippy::trait_duplication_in_bounds)]
             pub trait Bus: ::tock_registers::Address + sealed::Bus {
                 const SIZE: usize;

--- a/codegen/src/block_test_offsets.rs
+++ b/codegen/src/block_test_offsets.rs
@@ -4,7 +4,7 @@
 // Copyright Better Bytes 2026.
 
 use crate::block::{
-    bus_doc_comment, field_struct_doc_comment, interface_doc_comment, lens_doc_comment,
+    bus_doc_comment, field_struct_doc_comment, interface_doc_comment, lengths_doc_comment,
     real_doc_comment,
 };
 use crate::{new_doc_comment, register_map, test_util::assert_tokens_eq, Env::ProcMacro};
@@ -33,7 +33,7 @@ fn offsets() {
         }
     };
     let interface_comment = interface_doc_comment();
-    let lens_comment = lens_doc_comment();
+    let lengths_comment = lengths_doc_comment();
     let bus_comment = bus_doc_comment();
     let real_comment = real_doc_comment();
     let new_comment = new_doc_comment();
@@ -58,7 +58,7 @@ fn offsets() {
                 type padded_pos: ::tock_registers::Register<DataType = u8> + Read;
                 fn padded_pos(self) -> Self::padded_pos;
             }
-            #lens_comment pub mod lens {}
+            #lengths_comment pub mod lengths {}
             #bus_comment #[allow(clippy::trait_duplication_in_bounds)]
             pub trait Bus: ::tock_registers::Address + ::tock_registers::DataTypeBus<usize> +
                 ::tock_registers::DataTypeBus<u32> + ::tock_registers::DataTypeBus<u16> +

--- a/src/fake_register.rs
+++ b/src/fake_register.rs
@@ -166,7 +166,7 @@ impl sealed::Access for Safe {}
 /// struct Fake([Cell<u8>; 4]);
 /// impl<'f> storage::Interface for &'f Fake {
 ///     type scratch = FakeRegisterArray<
-///         Self, FakeRegister<&'f Cell<u8>, u8, Safe, Safe>, storage::lens::scratch>;
+///         Self, FakeRegister<&'f Cell<u8>, u8, Safe, Safe>, storage::lengths::scratch>;
 ///     fn scratch(self) -> Self::scratch {
 ///         FakeRegisterArray::new(self, |s, i| Some(
 ///             FakeRegister::new(s.0.get(i)?)

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -43,14 +43,14 @@ impl<'f> array_demo::Interface for &'f Fake {
     type counter = FakeRegisterArray<
         Self,
         FakeRegister<(Self, u8), u8, Safe, NoAccess>,
-        array_demo::lens::counter,
+        array_demo::lengths::counter,
     >;
     fn counter(
         self,
     ) -> FakeRegisterArray<
         Self,
         FakeRegister<(Self, u8), u8, Safe, NoAccess>,
-        array_demo::lens::counter,
+        array_demo::lengths::counter,
     > {
         FakeRegisterArray::new(self, |s, index| {
             if index >= 3 {
@@ -66,10 +66,11 @@ impl<'f> array_demo::Interface for &'f Fake {
         })
     }
 
-    type incrementers = FakeRegisterArray<Self, FakeIncrement<'f>, array_demo::lens::incrementers>;
+    type incrementers =
+        FakeRegisterArray<Self, FakeIncrement<'f>, array_demo::lengths::incrementers>;
     fn incrementers(
         self,
-    ) -> FakeRegisterArray<Self, FakeIncrement<'f>, array_demo::lens::incrementers> {
+    ) -> FakeRegisterArray<Self, FakeIncrement<'f>, array_demo::lengths::incrementers> {
         FakeRegisterArray::new(self, |s, index| {
             Some(FakeIncrement {
                 counter: &s.single_counter,

--- a/tests/nested_arrays.rs
+++ b/tests/nested_arrays.rs
@@ -86,7 +86,7 @@ pub fn check8<D: d::Interface>() {
     check7::<D>();
 }
 
-pub fn check9<E: RegisterArray<e::lens::array, Element: d::Interface>>() {
+pub fn check9<E: RegisterArray<e::lengths::array, Element: d::Interface>>() {
     check0::<<<<<E::Element as RegisterArray<_>>::Element as RegisterArray<_>>::Element
         as RegisterArray<_>>::Element as RegisterArray<_>>::Element>();
     check1::<<<<E::Element as RegisterArray<_>>::Element as RegisterArray<_>>::Element


### PR DESCRIPTION
When I first was reading things, I parsed `lens` in the optics sense, i.e., some kind of view over (part of?) an Interface. That noun stuck in my head even as I understood what the `lens` module was doing; it took me longer than I care to admit to realize that it was the plural of `len` 😬 .

I did a quick search, and while `len` is canonical for length in various Rust things, I can't find any example of other things using plural `len`s, but did find lots of examples of `lens as 'view'`.

This renames `lens` to `lengths` everywhere. If it was just internal, I'd leave it, but as part of the public interface I feel like the more explicit noun is clearer and removes a potential ambiguity.

Claude did the refactor, lovely tool for stuff like this...

This might be annoying churn, and feel free to close/dismiss it if you decide it's on that side of the line.