### PR TITLE
Don't use `byte_add` on pointers to MMIO memory.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ miri_64: nightly_toolchain
 .PHONY: miri_quick
 miri_quick: nightly_toolchain
 	cd nightly && RUSTFLAGS="-D warnings" \
-		cargo miri test --manifest-path=../Cargo.toml --test=mmio
+		cargo miri test --manifest-path=../Cargo.toml --test=mmio_nonnull
 
 .PHONY: no_default_features
 no_default_features: toolchain

--- a/src/mmio.rs
+++ b/src/mmio.rs
@@ -45,14 +45,6 @@ macro_rules! mmio_structs {
             }
         }
 
-        impl Address for $name {
-            unsafe fn byte_add(self, offset: usize) -> Self {
-                // Safety: The safety requirements of Address::byte_add require self + offset to
-                // remain within this register span and not wrap.
-                Self(unsafe { self.0.byte_add(offset) })
-            }
-        }
-
         // Safety: Mmio* does not expose safe operations to access registers on its own. Instead,
         // it is used through two types:
         // 1. The register accessor structs, which are always !Send + !Sync
@@ -77,65 +69,94 @@ mmio_structs! {
     Mmio64Nullable(*mut ())["64"]
 }
 
-/// Macro to provide the from_addr functions for the non-nullable Mmio* structs.
-macro_rules! from_addr_nonnull {
-    [$($name:ident)*] => {$(impl $name {
-        /// Constructs a new MMIO register bus pointing to the given address. If you have an
-        /// address from a datasheet and want to access it as a register struct, this is probably
-        /// the method you want.
-        ///
-        /// The MMIO register bus is created without provenance. That is fine for accessing MMIO
-        /// memory, but it means it cannot be used to access Rust memory. If you want to access
-        /// Rust memory (i.e. if this is pointing somewhere other than MMIO memory) then you must
-        /// use [`new`](Self::new) to construct this bus instead.
-        ///
-        /// # Panics
-        /// Panics if the provided address is null, and panics during const evaluation if the
-        /// pointer cannot be determined to be null or not. If you want to access a register at
-        /// address 0, use one of the nullable MMIO structs.
-        ///
-        /// Additionally, panics if this system's bus width does not match this bus type.
-        #[track_caller]
-        pub const fn from_addr(addr: usize) -> Self {
-            Self::width_check();
-            // TODO: Once the MSRV reaches:
-            // 1.84: replace the pointer cast with core::ptr::without_provenance_mut
-            // 1.85: replace NonNull::new_unchecked with NonNull::new
-            // 1.89: replace NonNull::new/new_unchecked with NonNull::without_provenance (this
-            //       obsoletes the above two steps).
-            assert!(addr != 0);
-            let ptr = addr as *mut ();
-            // Safety: We've already confirmed that the address is not null (ptr::null() documents
-            // that null pointers have address 0), and we have not changed the address, so ptr is
-            // not null.
-            Self(unsafe { NonNull::new_unchecked(ptr) })
+/// Macro to provide impls specific to the non-nullable Mmio* structs.
+macro_rules! impl_nonnull {
+    [$($name:ident)*] => {$(
+        impl $name {
+            /// Constructs a new MMIO register bus pointing to the given
+            /// address. If you have an address from a datasheet and want to
+            /// access it as a register struct, this is probably the method you
+            /// want.
+            ///
+            /// The MMIO register bus is created without provenance. That is
+            /// fine for accessing MMIO memory, but it means it cannot be used
+            /// to access Rust memory. If you want to access Rust memory (i.e.
+            /// if this is pointing somewhere other than MMIO memory) then you
+            /// must use [`new`](Self::new) to construct this bus instead.
+            ///
+            /// # Panics
+            /// Panics if the provided address is null, and panics during const
+            /// evaluation if the pointer cannot be determined to be null or
+            /// not. If you want to access a register at address 0, use one of
+            /// the nullable MMIO structs.
+            ///
+            /// Additionally, panics if this system's bus width does not match
+            /// this bus type.
+            #[track_caller]
+            pub const fn from_addr(addr: usize) -> Self {
+                Self::width_check();
+                // TODO: Once the MSRV reaches:
+                // 1.84: replace the pointer cast with
+                //       core::ptr::without_provenance_mut
+                // 1.85: replace NonNull::new_unchecked with NonNull::new
+                // 1.89: replace NonNull::new/new_unchecked with
+                //       NonNull::without_provenance (this obsoletes the above
+                //       two steps).
+                assert!(addr != 0);
+                let ptr = addr as *mut ();
+                // Safety: We've already confirmed that the address is not null
+                // (ptr::null() documents that null pointers have address 0),
+                // and we have not changed the address, so ptr is not null.
+                Self(unsafe { NonNull::new_unchecked(ptr) })
+            }
         }
-    })*}
+
+        impl Address for $name {
+            unsafe fn byte_add(self, offset: usize) -> Self {
+                let new_ptr = self.0.as_ptr().wrapping_byte_add(offset);
+                // Safety: `self.0` is a NonNull<()> so we know it isn't null.
+                // Address::byte_add's safety invariant requires this offset to
+                // remain within this register span and not wrap. Therefore the
+                // new address is not null.
+                Self(unsafe { NonNull::new_unchecked(new_ptr) })
+            }
+        }
+    )*}
 }
 
-from_addr_nonnull![Mmio32 Mmio64];
+impl_nonnull![Mmio32 Mmio64];
 
-/// Macro to provide the from_addr functions for the Mmio*Nullable structs.
-macro_rules! from_addr_nullable {
-    [$($name:ident)*] => {$(impl $name {
-        /// Constructs a new MMIO register bus pointing to the given address. If you have an
-        /// address from a datasheet and want to access it as a register struct, this is probably
-        /// the method you want.
-        ///
-        /// The MMIO register bus is created without provenance. That is fine for accessing MMIO
-        /// memory, but it means it cannot be used to access Rust memory. If you want to access
-        /// Rust memory (i.e. if this is pointing somewhere other than MMIO memory) then you must
-        /// use [`new`](Self::new) to construct this bus instead.
-        pub const fn from_addr(addr: usize) -> Self {
-            Self::width_check();
-            // TODO: Once the MSRV reaches 1.84, replace this cast with
-            // core::ptr::without_provenance_mut.
-            Self(addr as *mut ())
+/// Macro to provide impls specific to the Mmio*Nullable structs.
+macro_rules! impl_nullable {
+    [$($name:ident)*] => {$(
+        impl $name {
+            /// Constructs a new MMIO register bus pointing to the given
+            /// address. If you have an address from a datasheet and want to
+            /// access it as a register struct, this is probably the method you
+            /// want.
+            ///
+            /// The MMIO register bus is created without provenance. That is
+            /// fine for accessing MMIO memory, but it means it cannot be used
+            /// to access Rust memory. If you want to access Rust memory (i.e.
+            /// if this is pointing somewhere other than MMIO memory) then you
+            /// must use [`new`](Self::new) to construct this bus instead.
+            pub const fn from_addr(addr: usize) -> Self {
+                Self::width_check();
+                // TODO: Once the MSRV reaches 1.84, replace this cast with
+                // core::ptr::without_provenance_mut.
+                Self(addr as *mut ())
+            }
         }
-    })*}
+
+        impl Address for $name {
+            unsafe fn byte_add(self, offset: usize) -> Self {
+                Self(self.0.wrapping_byte_add(offset))
+            }
+        }
+    )*}
 }
 
-from_addr_nullable![Mmio32Nullable Mmio64Nullable];
+impl_nullable![Mmio32Nullable Mmio64Nullable];
 
 /// Macro to implement the Bus traits for the Mmio* structs.
 macro_rules! bus_impls {

--- a/tests/mmio_nonnull.rs
+++ b/tests/mmio_nonnull.rs
@@ -58,6 +58,11 @@ struct OuterBlock {
     flat_array_reference: [u8; 2],
 }
 
+#[cfg(target_pointer_width = "32")]
+type Mmio = Mmio32;
+#[cfg(target_pointer_width = "64")]
+type Mmio = Mmio64;
+
 #[test]
 fn mmio() {
     let peripheral = UnsafeCell::new(OuterBlock {
@@ -91,10 +96,7 @@ fn mmio() {
         flat_array: [44, 45],
         flat_array_reference: [46, 47],
     });
-    #[cfg(target_pointer_width = "32")]
-    let mmio = Mmio32::new(NonNull::new(peripheral.get()).unwrap().cast());
-    #[cfg(target_pointer_width = "64")]
-    let mmio = Mmio64::new(NonNull::new(peripheral.get()).unwrap().cast());
+    let mmio = Mmio::new(NonNull::new(peripheral.get()).unwrap().cast());
     let registers = unsafe { outer_block::Real::new(mmio) };
     // Pointer offset validation: verifies that pointer offsets are correctly calculated through
     // the various field types.
@@ -161,4 +163,45 @@ fn mmio() {
     registers.scalar().set(u64::MAX);
     assert_eq!(unsafe { (*peripheral.get()).scalar }, u64::MAX);
     assert_eq!(registers.overlapped().get(), 0xff);
+}
+
+/// This performs offsetting operations using a base pointer without provenance.
+/// This is an accurate model for real registers (it differs from [mmio] which
+/// uses pointers with provenance to access a stack variable). In Miri, this can
+/// catch UB caused by using offset functions that require the pointers to point
+/// at allocations.
+#[test]
+fn offset() {
+    let mmio = Mmio::new(NonNull::dangling());
+    // Safety: This is not sound, there is not actually an outer_block at this
+    // address. But this test never accesses the values, only computes offsets,
+    // so it should not trigger UB.
+    let registers = unsafe { outer_block::Real::new(mmio) };
+
+    // Calculate the offsets for each register in outer_block.
+    registers.scalar();
+    registers.overlapped();
+    fn check_inner(inner: inner_block::Real<Mmio>) {
+        inner.scalar_definition();
+        inner.array_definition().get(0).unwrap().get(0).unwrap();
+        inner.array_definition().get(0).unwrap().get(1).unwrap();
+        inner.array_definition().get(1).unwrap().get(0).unwrap();
+        inner.array_definition().get(1).unwrap().get(1).unwrap();
+        inner.array_definition().get(2).unwrap().get(0).unwrap();
+        inner.array_definition().get(2).unwrap().get(1).unwrap();
+        inner.scalar_reference();
+        inner.array_reference().get(0).unwrap().get(0).unwrap();
+        inner.array_reference().get(0).unwrap().get(1).unwrap();
+        inner.array_reference().get(1).unwrap().get(0).unwrap();
+        inner.array_reference().get(1).unwrap().get(1).unwrap();
+        inner.array_reference().get(2).unwrap().get(0).unwrap();
+        inner.array_reference().get(2).unwrap().get(1).unwrap();
+    }
+    check_inner(registers.nested());
+    check_inner(registers.nested_array().get(0).unwrap());
+    check_inner(registers.nested_array().get(1).unwrap());
+    registers.flat_array().get(0).unwrap();
+    registers.flat_array().get(1).unwrap();
+    registers.flat_array_reference().get(0).unwrap();
+    registers.flat_array_reference().get(1).unwrap();
 }

--- a/tests/mmio_nullable.rs
+++ b/tests/mmio_nullable.rs
@@ -1,0 +1,207 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+// Copyright Better Bytes 2026.
+
+//! This test verifies that the Mmio32Nullable and Mmio64Nullable buses work
+//! correctly. Indirectly, it also verifies that register offsets are calculated
+//! correctly. It is designed to run in Miri on 32-bit and 64-bit targets.
+
+#![no_std]
+
+use core::cell::UnsafeCell;
+use tock_registers::{register_map, Mmio32Nullable, Mmio64Nullable, Read, RegisterArray, Write};
+use {inner_block::Interface as _, outer_block::Interface as _};
+
+register_map! {
+    #![buses(Mmio32Nullable, Mmio64Nullable)]
+    // External registers to reference.
+    a: u8 { Read, Write },
+    b: u16 { Read, Write },
+    inner_block {
+        0 => scalar_definition: usize { Read, Write },
+        [4, 8] => _: [4, 8],
+        [8, 16] => array_definition: [[u32; 2]; 3] { Read, Write },
+        [32, 40] => scalar_reference: a,
+        [33, 41] => _,
+        [36, 44] => array_reference: [[b; 2]; 3],
+    },
+    outer_block {
+        0 => scalar: u64 { Read, Write },
+        #[aliased]
+        1 => overlapped: u8 { Read, Write },
+        8 => nested: inner_block,
+        [56, 64] => nested_array: [inner_block; 2],
+        [152, 176] => flat_array: [u8; 2] { Read },
+        [154, 178] => flat_array_reference: [a; 2],
+    },
+}
+
+#[derive(PartialEq)]
+#[repr(C)]
+struct InnerBlock {
+    scalar_definition: usize,
+    _padding0: usize,
+    array_definition: [[u32; 2]; 3],
+    scalar_reference: u8,
+    _padding1: [u8; 3],
+    array_reference: [[u16; 2]; 3],
+}
+
+#[derive(PartialEq)]
+#[repr(C)]
+struct OuterBlock {
+    scalar: u64,
+    nested: InnerBlock,
+    nested_array: [InnerBlock; 2],
+    flat_array: [u8; 2],
+    flat_array_reference: [u8; 2],
+}
+
+#[cfg(target_pointer_width = "32")]
+type Mmio = Mmio32Nullable;
+#[cfg(target_pointer_width = "64")]
+type Mmio = Mmio64Nullable;
+
+#[test]
+fn mmio() {
+    let peripheral = UnsafeCell::new(OuterBlock {
+        scalar: 1,
+        nested: InnerBlock {
+            scalar_definition: 2,
+            _padding0: 0,
+            array_definition: [[3, 4], [5, 6], [7, 8]],
+            scalar_reference: 9,
+            _padding1: [0; 3],
+            array_reference: [[10, 11], [12, 13], [14, 15]],
+        },
+        nested_array: [
+            InnerBlock {
+                scalar_definition: 16,
+                _padding0: 0,
+                array_definition: [[17, 18], [19, 20], [21, 22]],
+                scalar_reference: 23,
+                _padding1: [0; 3],
+                array_reference: [[24, 25], [26, 27], [28, 29]],
+            },
+            InnerBlock {
+                scalar_definition: 30,
+                _padding0: 0,
+                array_definition: [[31, 32], [33, 34], [35, 36]],
+                scalar_reference: 37,
+                _padding1: [0; 3],
+                array_reference: [[38, 39], [40, 41], [42, 43]],
+            },
+        ],
+        flat_array: [44, 45],
+        flat_array_reference: [46, 47],
+    });
+    let mmio = Mmio::new(peripheral.get().cast());
+    let registers = unsafe { outer_block::Real::new(mmio) };
+    // Pointer offset validation: verifies that pointer offsets are correctly calculated through
+    // the various field types.
+    assert_eq!(registers.scalar().get(), 1);
+    assert_eq!(registers.overlapped().get(), 0);
+    assert_eq!(registers.nested().scalar_definition().get(), 2);
+    let array = registers.nested().array_definition();
+    assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 3);
+    assert_eq!(array.get(0).unwrap().get(1).unwrap().get(), 4);
+    assert_eq!(array.get(1).unwrap().get(0).unwrap().get(), 5);
+    assert_eq!(array.get(1).unwrap().get(1).unwrap().get(), 6);
+    assert_eq!(array.get(2).unwrap().get(0).unwrap().get(), 7);
+    assert_eq!(array.get(2).unwrap().get(1).unwrap().get(), 8);
+    assert_eq!(registers.nested().scalar_reference().get(), 9);
+    let array = registers.nested().array_reference();
+    assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 10);
+    assert_eq!(array.get(0).unwrap().get(1).unwrap().get(), 11);
+    assert_eq!(array.get(1).unwrap().get(0).unwrap().get(), 12);
+    assert_eq!(array.get(1).unwrap().get(1).unwrap().get(), 13);
+    assert_eq!(array.get(2).unwrap().get(0).unwrap().get(), 14);
+    assert_eq!(array.get(2).unwrap().get(1).unwrap().get(), 15);
+    let nested = registers.nested_array().get(0).unwrap();
+    assert_eq!(nested.scalar_definition().get(), 16);
+    let array = nested.array_definition();
+    assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 17);
+    assert_eq!(array.get(0).unwrap().get(1).unwrap().get(), 18);
+    assert_eq!(array.get(1).unwrap().get(0).unwrap().get(), 19);
+    assert_eq!(array.get(1).unwrap().get(1).unwrap().get(), 20);
+    assert_eq!(array.get(2).unwrap().get(0).unwrap().get(), 21);
+    assert_eq!(array.get(2).unwrap().get(1).unwrap().get(), 22);
+    assert_eq!(nested.scalar_reference().get(), 23);
+    let array = nested.array_reference();
+    assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 24);
+    assert_eq!(array.get(0).unwrap().get(1).unwrap().get(), 25);
+    assert_eq!(array.get(1).unwrap().get(0).unwrap().get(), 26);
+    assert_eq!(array.get(1).unwrap().get(1).unwrap().get(), 27);
+    assert_eq!(array.get(2).unwrap().get(0).unwrap().get(), 28);
+    assert_eq!(array.get(2).unwrap().get(1).unwrap().get(), 29);
+    let nested = registers.nested_array().get(1).unwrap();
+    assert_eq!(nested.scalar_definition().get(), 30);
+    let array = nested.array_definition();
+    assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 31);
+    assert_eq!(array.get(0).unwrap().get(1).unwrap().get(), 32);
+    assert_eq!(array.get(1).unwrap().get(0).unwrap().get(), 33);
+    assert_eq!(array.get(1).unwrap().get(1).unwrap().get(), 34);
+    assert_eq!(array.get(2).unwrap().get(0).unwrap().get(), 35);
+    assert_eq!(array.get(2).unwrap().get(1).unwrap().get(), 36);
+    assert_eq!(nested.scalar_reference().get(), 37);
+    let array = nested.array_reference();
+    assert_eq!(array.get(0).unwrap().get(0).unwrap().get(), 38);
+    assert_eq!(array.get(0).unwrap().get(1).unwrap().get(), 39);
+    assert_eq!(array.get(1).unwrap().get(0).unwrap().get(), 40);
+    assert_eq!(array.get(1).unwrap().get(1).unwrap().get(), 41);
+    assert_eq!(array.get(2).unwrap().get(0).unwrap().get(), 42);
+    assert_eq!(array.get(2).unwrap().get(1).unwrap().get(), 43);
+    assert_eq!(registers.flat_array().get(0).unwrap().get(), 44);
+    assert_eq!(registers.flat_array().get(1).unwrap().get(), 45);
+    assert_eq!(registers.flat_array_reference().get(0).unwrap().get(), 46);
+    assert_eq!(registers.flat_array_reference().get(1).unwrap().get(), 47);
+    // External write: verify Mmio can handle varying register values.
+    unsafe { (*peripheral.get()).scalar = 48 };
+    assert_eq!(registers.scalar().get(), 48);
+    // Perform a write.
+    registers.scalar().set(u64::MAX);
+    assert_eq!(unsafe { (*peripheral.get()).scalar }, u64::MAX);
+    assert_eq!(registers.overlapped().get(), 0xff);
+}
+
+/// This performs offsetting operations using a base pointer without provenance.
+/// This is an accurate model for real registers (it differs from [mmio] which
+/// uses pointers with provenance to access a stack variable). In Miri, this can
+/// catch UB caused by using offset functions that require the pointers to point
+/// at allocations.
+#[test]
+fn offset() {
+    let mmio = Mmio::new(core::ptr::null_mut());
+    // Safety: This is not sound, there is not actually an outer_block at this
+    // address. But this test never accesses the values, only computes offsets,
+    // so it should not trigger UB.
+    let registers = unsafe { outer_block::Real::new(mmio) };
+
+    // Calculate the offsets for each register in outer_block.
+    registers.scalar();
+    registers.overlapped();
+    fn check_inner(inner: inner_block::Real<Mmio>) {
+        inner.scalar_definition();
+        inner.array_definition().get(0).unwrap().get(0).unwrap();
+        inner.array_definition().get(0).unwrap().get(1).unwrap();
+        inner.array_definition().get(1).unwrap().get(0).unwrap();
+        inner.array_definition().get(1).unwrap().get(1).unwrap();
+        inner.array_definition().get(2).unwrap().get(0).unwrap();
+        inner.array_definition().get(2).unwrap().get(1).unwrap();
+        inner.scalar_reference();
+        inner.array_reference().get(0).unwrap().get(0).unwrap();
+        inner.array_reference().get(0).unwrap().get(1).unwrap();
+        inner.array_reference().get(1).unwrap().get(0).unwrap();
+        inner.array_reference().get(1).unwrap().get(1).unwrap();
+        inner.array_reference().get(2).unwrap().get(0).unwrap();
+        inner.array_reference().get(2).unwrap().get(1).unwrap();
+    }
+    check_inner(registers.nested());
+    check_inner(registers.nested_array().get(0).unwrap());
+    check_inner(registers.nested_array().get(1).unwrap());
+    registers.flat_array().get(0).unwrap();
+    registers.flat_array().get(1).unwrap();
+    registers.flat_array_reference().get(0).unwrap();
+    registers.flat_array_reference().get(1).unwrap();
+}


### PR DESCRIPTION
The byte_add method on Rust pointers works within an allocation. There are a few reasons why our MMIO pointers might not point to an allocation:

1. The exact semantics of MMIO memory in Rust haven't been specified yet.
2. Null pointers do not point to an allocation.
3. We create our pointers with no provenance (or at least will once the MSRV is bumped to a verson that has `without_provenance`), and hence they are not derived from pointers that point to an allocation.

So it is unsound to call `byte_add` on these pointers. This PR instead uses `wrapping_byte_add`, which does not have the allocation requirement. This does not result in any change in generated code for the three drivers I ported in tock/tock#4772 (qemu_i486_virt, qemu_rv32_virt, qemu_rv64_virt).

`tests/mmio.rs` did not catch this unsoundness, because it uses pointers that point to a real Rust allocation. This change adds a new test case which exercises offsetting operations on a pointer that lacks provenance. I've verified that this new test case correctly catches the UB when run under Miri. I also split `tests/mmio.rs` into two files: `mmio_nullable.rs` which tests
Mmio32Nullable/Mmio64Nullable, and `mmio_nonnull.rs` which tests Mmio32/Mmio64.

Fixes #65

No AI was used in this PR.